### PR TITLE
Fix melee having healer color

### DIFF
--- a/BossMod/BossModule/BossModule.cs
+++ b/BossMod/BossModule/BossModule.cs
@@ -338,7 +338,7 @@ public abstract class BossModule : IDisposable
                         {
                             ClassCategory.Tank => Colors.Tank,
                             ClassCategory.Healer => Colors.Healer,
-                            ClassCategory.Melee => Colors.Healer,
+                            ClassCategory.Melee => Colors.Melee,
                             ClassCategory.Caster => Colors.Caster,
                             ClassCategory.PhysRanged => Colors.PhysRanged,
                             _ => color


### PR DESCRIPTION
I made a PR to the upstream a short bit ago and ended up testing it on BMR. I noticed melees were illustrated with healer colors and it looks like somebody made a copypasta error. This PR fixes that