### PR TITLE
Add new AOE mechanics and update state machines for Nier raids

### DIFF
--- a/BossMod/Modules/Shadowbringers/Alliance/A13Engels/A13Engels.cs
+++ b/BossMod/Modules/Shadowbringers/Alliance/A13Engels/A13Engels.cs
@@ -1,4 +1,65 @@
 ﻿namespace BossMod.Shadowbringers.Alliance.A13Engels;
 
+class DemolishStructureArenaChange(BossModule module) : Components.GenericAOEs(module)
+{
+    private static readonly AOEShapeRect square = new(5, 5, 5, InvertForbiddenZone: true);
+    private AOEInstance? _aoe;
+    public override IEnumerable<AOEInstance> ActiveAOEs(int slot, Actor actor) => Utils.ZeroOrOne(_aoe);
+
+    public override void OnCastStarted(Actor caster, ActorCastInfo spell)
+    {
+        if ((AID)spell.Action.ID == AID.DemolishStructure2 && Arena.Bounds == A13MarxEngels.StartingBounds)
+            _aoe = new(square, A13MarxEngels.TransitionSpot, Color: Colors.SafeFromAOE);
+    }
+
+    public override void OnEventEnvControl(byte index, uint state)
+    {
+        if (state == 0x00020001 && index == 0x0B)
+        {
+            Arena.Center = A13MarxEngels.SecondArenaCenter;
+            Arena.Bounds = A13MarxEngels.StartingBounds;
+            _aoe = null; //
+        }
+    }
+}
+
+class MarxSmash3(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.MarxSmash3), new AOEShapeRect(30, 60, DirectionOffset: 90.Degrees()));
+class MarxSmash2(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.MarxSmash2), new AOEShapeRect(30, 60, DirectionOffset: -90.Degrees()));
+class MarxSmash6(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.MarxSmash6), new AOEShapeRect(30, 30));
+class MarxSmash8(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.MarxSmash8), new AOEShapeRect(30, 30));
+class MarxSmash10(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.MarxSmash10), new AOEShapeRect(35, 30));
+class MarxSmash12(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.MarxSmash12), new AOEShapeRect(60, 60, DirectionOffset: 90.Degrees()));
+class MarxSmash13(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.MarxSmash13), new AOEShapeRect(60, 60, DirectionOffset: -90.Degrees()));
+
+class MarxCrush2(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.MarxCrush2), new AOEShapeRect(15, 15));
+
+class PrecisionGuidedMissile2(BossModule module) : Components.SpreadFromCastTargets(module, ActionID.MakeSpell(AID.PrecisionGuidedMissile2), 6);
+class LaserSight1(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.LaserSight1), new AOEShapeRect(100, 10));
+class GuidedMissile2(BossModule module) : Components.LocationTargetedAOEs(module, ActionID.MakeSpell(AID.GuidedMissile2), 6);
+class IncendiaryBombing2(BossModule module) : Components.LocationTargetedAOEs(module, ActionID.MakeSpell(AID.IncendiaryBombing2), 8);
+class IncendiaryBombing1(BossModule module) : Components.SpreadFromIcon(module, (uint)IconID.Spreadmarker, ActionID.MakeSpell(AID.IncendiaryBombing1), 8, 5);
+class DiffuseLaser(BossModule module) : Components.RaidwideCast(module, ActionID.MakeSpell(AID.DiffuseLaser));
+class SurfaceMissile2(BossModule module) : Components.LocationTargetedAOEs(module, ActionID.MakeSpell(AID.SurfaceMissile2), 6);
+
+class GuidedMissile : Components.StandardChasingAOEs
+{
+    public GuidedMissile(BossModule module) : base(module, new AOEShapeCircle(6), ActionID.MakeSpell(AID.GuidedMissile2), ActionID.MakeSpell(AID.GuidedMissile3), 5.5f, 1, 4) //float moveDistance, float secondsBetweenActivations, int maxCasts
+    {
+        ExcludedTargets = Raid.WithSlot(true).Mask();
+    }
+
+    public override void OnEventIcon(Actor actor, uint iconID)
+    {
+        if (iconID == (uint)IconID.GuidedMissile)
+            ExcludedTargets.Clear(Raid.FindSlot(actor.InstanceID));
+    }
+}
+
 [ModuleInfo(BossModuleInfo.Maturity.WIP, Contributors = "The Combat Reborn Team", GroupType = BossModuleInfo.GroupType.CFC, GroupID = 700, NameID = 9147)]
-public class A13MarxEngels(WorldState ws, Actor primary) : BossModule(ws, primary, new(900, 670), new ArenaBoundsCircle(30));
+public class A13MarxEngels(WorldState ws, Actor primary) : BossModule(ws, primary, StartingArenaCenter, StartingBounds)
+{
+    public static readonly WPos TransitionSpot = new(900, 697);
+    public static readonly WPos StartingArenaCenter = new(900, 670);
+    public static readonly WPos SecondArenaCenter = new(900, 785);
+    public static readonly ArenaBoundsSquare StartingBounds = new(30);
+}

--- a/BossMod/Modules/Shadowbringers/Alliance/A13Engels/A13EngelsEnums.cs
+++ b/BossMod/Modules/Shadowbringers/Alliance/A13Engels/A13EngelsEnums.cs
@@ -19,63 +19,82 @@ public enum OID : uint
 
 public enum AID : uint
 {
-    AutoAttack1 = 19041, // Ally2P1->self, no cast, range 30 circle
-    AutoAttack2 = 19043, // Ally2P1->ReverseJointedGoliath, no cast, single-target
     AutoAttack3 = 872, // SmallBiped->player, no cast, single-target
     AutoAttackAutomaticCannon = 18264, // ReverseJointedGoliath->player, no cast, single-target
-    AreaBombardment = 18256, // Boss->self, 3.0s cast, single-target
     ArmLaser = 18263, // ReverseJointedGoliath->self, 3.0s cast, range 30 90-degree cone
-    AutomaticCannon1 = 18257, // Boss->self, no cast, single-target
-    AutomaticCannon2 = 18258, // EngelsHelper1->player, no cast, single-target
+
     CrushingWheel1 = 18248, // Boss->self, no cast, single-target
     CrushingWheel2 = 18251, // MarxL/MarxR->self, 12.0s cast, range 20 width 30 rect
-    DemolishStructure1 = 18244, // Boss->self, no cast, single-target
-    DemolishStructure2 = 18245, // EngelsHelper1->self, 9.3s cast, range 50 circle
-    DiffuseLaser = 18261, // Boss->self, 4.0s cast, range 60 width 60 rect
-    EnergyBarrage = 18236, // Boss->self, 3.0s cast, single-target
-    EnergyBlast = 18238, // EngelsHelper1->self, no cast, range 75 circle
-    EnergyDispersal = 18237, // EngelsHelper1->self, no cast, range 4 circle
+    RadiateHeat = 18252, // EngelsHelper1->self, no cast, range 50 circle
     Frack = 18253, // EngelsHelper1->self, no cast, range 15 circle
+    IncendiarySaturationBombing1 = 18254, // Boss->self, 3.0s cast, single-target
+    IncendiarySaturationBombing2 = 18255, // EngelsHelper1->self, 6.0s cast, range 30 width 60 rect
+    AreaBombardment = 18256, // Boss->self, 3.0s cast, single-target
+
+    AutomaticCannon1 = 18257, // Boss->self, no cast, single-target
+    AutomaticCannon2 = 18258, // EngelsHelper1->player, no cast, single-target
+
+    DiffuseLaser = 18261, // Boss->self, 4.0s cast, range 60 width 60 rect
+
+    // Nox
     GuidedMissile1 = 18229, // Boss->self, 3.5s cast, single-target
     GuidedMissile2 = 18230, // EngelsHelper1->location, 5.0s cast, range 6 circle
     GuidedMissile3 = 18231, // EngelsHelper1->location, no cast, range 6 circle
+
     IncendiaryBombing1 = 18232, // Boss->self, 5.0s cast, single-target
     IncendiaryBombing2 = 18233, // EngelsHelper1->location, 4.0s cast, range 8 circle
-    IncendiarySaturationBombing1 = 18254, // Boss->self, 3.0s cast, single-target
-    IncendiarySaturationBombing2 = 18255, // EngelsHelper1->self, 6.0s cast, range 30 width 60 rect
+
+    // Persistent Line AOE
     LaserSight1 = 18234, // Boss->self, 4.1s cast, range 100 width 20 rect
     LaserSight2 = 18235, // EngelsHelper1->self, no cast, range 100 width 20 rect
+
+    // Towers
+    EnergyBarrage = 18236, // Boss->self, 3.0s cast, single-target
+    EnergyDispersal = 18237, // EngelsHelper1->self, no cast, range 4 circle
+    EnergyBlast = 18238, // EngelsHelper1->self, no cast, range 75 circle
+    UnknownAbility2 = 18239, // Boss->self, no cast, single-target
+
+    SurfaceMissile1 = 18227, // Boss->self, 3.5s cast, single-target
+    SurfaceMissile2 = 18228, // EngelsHelper1->location, 4.0s cast, range 6 circle
+
     MarxActivation = 18600, // Boss->self, 3.0s cast, single-target
+    DemolishStructure1 = 18244, // Boss->self, no cast, single-target
+    DemolishStructure2 = 18245, // EngelsHelper1->self, 9.3s cast, range 50 circle
     MarxCrush1 = 18246, // Boss->self, 6.0s cast, single-target
     MarxCrush2 = 18247, // EngelsHelper1->self, 6.0s cast, range 15 width 30 rect
+
     MarxSmash1 = 18214, // Boss->self, 6.0s cast, single-target
     MarxSmash2 = 18215, // Boss->self, 6.0s cast, single-target
-    MarxSmash3 = 18216, // EngelsHelper1->self, 1.6s cast, range 60 width 30 rect
-    MarxSmash4 = 18217, // EngelsHelper1->self, 1.6s cast, range 60 width 30 rect
+    MarxSmash3 = 18216, // EngelsHelper1->self, 1.6s cast, range 60 width 30 rect // Half room right side
+    MarxSmash4 = 18217, // EngelsHelper1->self, 1.6s cast, range 60 width 30 rect // Half room left side
     MarxSmash5 = 18218, // Boss->self, 6.0s cast, single-target
-    MarxSmash6 = 18219, // EngelsHelper1->self, 1.5s cast, range 30 width 60 rect
+    MarxSmash6 = 18219, // EngelsHelper1->self, 1.5s cast, range 30 width 60 rect // Half room front side
     MarxSmash7 = 18220, // Boss->self, no cast, single-target
-    MarxSmash8 = 18221, // EngelsHelper1->self, 0.5s cast, range 60 width 30 rect
+    MarxSmash8 = 18221, // EngelsHelper1->self, 0.5s cast, range 60 width 30 rect // Middle of arena front to back cleave
     MarxSmash9 = 18222, // Boss->self, 6.0s cast, single-target
-    MarxSmash10 = 18223, // EngelsHelper1->self, 1.5s cast, range 35 width 60 rect
+    MarxSmash10 = 18223, // EngelsHelper1->self, 1.5s cast, range 35 width 60 rect // Half room back side
     MarxSmash11 = 18224, // Boss->self, no cast, single-target
-    MarxSmash12 = 18225, // EngelsHelper1->self, 0.5s cast, range 60 width 20 rect
-    MarxSmash13 = 18226, // EngelsHelper1->self, 0.5s cast, range 60 width 20 rect
+    MarxSmash12 = 18225, // EngelsHelper1->self, 0.5s cast, range 60 width 20 rect // Side of arena cleave
+    MarxSmash13 = 18226, // EngelsHelper1->self, 0.5s cast, range 60 width 20 rect // Side of arena cleave
+
     MarxThrust1 = 18262, // MarxHelper2/MarxHelper1->self, 5.0s cast, single-target
     MarxThrust2 = 18684, // EngelsHelper1->self, 5.5s cast, range 30 width 20 rect
+
+    // Tankbuster spreads
     PrecisionGuidedMissile1 = 18259, // Boss->self, 4.0s cast, single-target
     PrecisionGuidedMissile2 = 18260, // EngelsHelper1->players, 4.0s cast, range 6 circle
-    RadiateHeat = 18252, // EngelsHelper1->self, no cast, range 50 circle
+
+    WideAngleDiffuseLaser1 = 18240, // Boss->self, no cast, single-target
+    WideAngleDiffuseLaser2 = 18241, // EngelsHelper1->self, no cast, range 60 width 60 rect
+    UnknownAbility3 = 18243, // Boss->self, no cast, single-target
+
+    // 2P abilities, ignore
+    AutoAttack1 = 19041, // Ally2P1->self, no cast, range 30 circle
+    AutoAttack2 = 19043, // Ally2P1->ReverseJointedGoliath, no cast, single-target
+    UnknownAbility1 = 19045, // Ally2P1->location, no cast, single-target
     SaturationBombingManeuver1 = 18896, // Ally2P1->self, 4.0s cast, range 75 circle
     SaturationBombingManeuver2 = 19042, // Ally2P2->self, 5.0s cast, range 75 circle
     SaturationBombingManeuver3 = 19044, // Ally2P2->self, 5.0s cast, range 75 circle
-    SurfaceMissile1 = 18227, // Boss->self, 3.5s cast, single-target
-    SurfaceMissile2 = 18228, // EngelsHelper1->location, 4.0s cast, range 6 circle
-    UnknownAbility1 = 19045, // Ally2P1->location, no cast, single-target
-    UnknownAbility2 = 18239, // Boss->self, no cast, single-target
-    UnknownAbility3 = 18243, // Boss->self, no cast, single-target
-    WideAngleDiffuseLaser1 = 18240, // Boss->self, no cast, single-target
-    WideAngleDiffuseLaser2 = 18241, // EngelsHelper1->self, no cast, range 60 width 60 rect
 }
 
 public enum SID : uint
@@ -86,7 +105,7 @@ public enum SID : uint
 
 public enum IconID : uint
 {
-    Icon198 = 198, // player
-    Icon23 = 23, // player
-    Nox = 197, // player chasing AOE icon
+    Tankbuster = 198, // player tankbuster
+    Spreadmarker = 23, // player Spreadmarker
+    GuidedMissile = 197, // player chasing AOE icon
 }

--- a/BossMod/Modules/Shadowbringers/Alliance/A13Engels/A13EngelsStates.cs
+++ b/BossMod/Modules/Shadowbringers/Alliance/A13Engels/A13EngelsStates.cs
@@ -4,6 +4,24 @@ class A13MarxEngelsStates : StateMachineBuilder
 {
     public A13MarxEngelsStates(BossModule module) : base(module)
     {
-        TrivialPhase();
+        TrivialPhase()
+            .ActivateOnEnter<DemolishStructureArenaChange>()
+            .ActivateOnEnter<MarxSmash3>()
+            .ActivateOnEnter<MarxSmash2>()
+            .ActivateOnEnter<PrecisionGuidedMissile2>()
+            .ActivateOnEnter<DiffuseLaser>()
+            .ActivateOnEnter<LaserSight1>()
+            .ActivateOnEnter<GuidedMissile2>()
+            .ActivateOnEnter<IncendiaryBombing2>()
+            //.ActivateOnEnter<IncendiaryBombing1>()
+            .ActivateOnEnter<GuidedMissile>()
+            .ActivateOnEnter<DiffuseLaser>()
+            .ActivateOnEnter<MarxSmash6>()
+            //.ActivateOnEnter<MarxSmash8>()
+            //.ActivateOnEnter<MarxSmash10>() needs placement adjustment
+            .ActivateOnEnter<MarxSmash12>()
+            .ActivateOnEnter<MarxSmash13>()
+            .ActivateOnEnter<MarxCrush2>()
+            .ActivateOnEnter<SurfaceMissile2>();
     }
 }

--- a/BossMod/Modules/Shadowbringers/Alliance/A34RedGirlP1/A34RedGirlP1.cs
+++ b/BossMod/Modules/Shadowbringers/Alliance/A34RedGirlP1/A34RedGirlP1.cs
@@ -5,6 +5,7 @@ class ShockWhite2(BossModule module) : Components.LocationTargetedAOEs(module, A
 class ShockBlack2(BossModule module) : Components.LocationTargetedAOEs(module, ActionID.MakeSpell(AID.ShockBlack2), 5);
 class GenerateBarrier2(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.GenerateBarrier2), new AOEShapeRect(18, 1.5f));
 class GenerateBarrier3(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.GenerateBarrier3), new AOEShapeRect(24, 1.5f));
+class DiffuseEnergy1(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.DiffuseEnergy1), new AOEShapeCone(12, 60.Degrees()));
 
 [ModuleInfo(BossModuleInfo.Maturity.WIP, Contributors = "The Combat Reborn Team", GroupType = BossModuleInfo.GroupType.CFC, GroupID = 779, NameID = 9920)]
 public class A34RedGirlP1(WorldState ws, Actor primary) : BossModule(ws, primary, new(845, -851), new ArenaBoundsRect(19, 20));

--- a/BossMod/Modules/Shadowbringers/Alliance/A34RedGirlP1/A34RedGirlP1States.cs
+++ b/BossMod/Modules/Shadowbringers/Alliance/A34RedGirlP1/A34RedGirlP1States.cs
@@ -4,6 +4,12 @@ class A34RedGirlP1States : StateMachineBuilder
 {
     public A34RedGirlP1States(BossModule module) : base(module)
     {
-        TrivialPhase();
+        TrivialPhase()
+            //.ActivateOnEnter<Cruelty1>()
+            //.ActivateOnEnter<GenerateBarrier2>()
+            //.ActivateOnEnter<GenerateBarrier3>()
+            //.ActivateOnEnter<DiffuseEnergy1>()
+            .ActivateOnEnter<ShockWhite2>()
+            .ActivateOnEnter<ShockBlack2>();
     }
 }

--- a/BossMod/Modules/Shadowbringers/Alliance/A34RedGirlP2/A34RedGirlP2Enums.cs
+++ b/BossMod/Modules/Shadowbringers/Alliance/A34RedGirlP2/A34RedGirlP2Enums.cs
@@ -15,14 +15,9 @@ public enum OID : uint
 
 public enum AID : uint
 {
-    BladeFlurry1 = 23788, // Ally2B->Boss, no cast, single-target
-    BladeFlurry2 = 23789, // Ally2B->Boss, no cast, single-target
-    DancingBlade = 23790, // Ally2B->Boss, no cast, width 2 rect charge
-    BalancedEdge = 23791, // Ally2B->self, 2.0s cast, range 5 circle
     Cruelty1 = 24595, // Boss->self, 5.0s cast, single-target
     Cruelty2 = 24596, // Helper->location, no cast, range 75 circle
     BossAutoAttack = 24597, // Helper->player, no cast, single-target
-    WhirlingAssault = 23792, // Ally2B->self, 2.0s cast, range 40 width 4 rect
     ChildsPlay1 = 24612, // Boss/RedGirl1->self, 10.0s cast, single-target
     Explosion = 24614, // BlackPylon->self, 15.0s cast, range 9 circle
     Shockwave = 24590, // Boss->self, 2.0s cast, single-target
@@ -39,7 +34,6 @@ public enum AID : uint
     GenerateBarrier7 = 25363, // Helper->self, no cast, range 24 width 3 rect
     PointWhite2 = 24609, // WhiteLance->self, no cast, range 24 width 6 rect
     RecreateMeteor = 24903, // Boss->self, 2.0s cast, single-target
-    UnknownAbility = 18683, // Ally2B->location, no cast, single-target
     WipeWhite = 24588, // Helper->self, 13.0s cast, range 75 circle
     WipeBlack = 24589, // Helper->self, 13.0s cast, range 75 circle
     Replicate = 24587, // Boss->self, 3.0s cast, single-target
@@ -49,6 +43,14 @@ public enum AID : uint
     ManipulateEnergy2 = 24602, // Helper->player, no cast, range 3 circle
     ChildsPlay2 = 24613, // Boss->self, 10.0s cast, single-target
     ManipulateEnergy3 = 24600, // Boss->self, 4.0s cast, single-target
+
+    // 2B abilties, ignore
+    BladeFlurry1 = 23788, // Ally2B->Boss, no cast, single-target
+    BladeFlurry2 = 23789, // Ally2B->Boss, no cast, single-target
+    DancingBlade = 23790, // Ally2B->Boss, no cast, width 2 rect charge
+    BalancedEdge = 23791, // Ally2B->self, 2.0s cast, range 5 circle
+    WhirlingAssault = 23792, // Ally2B->self, 2.0s cast, range 40 width 4 rect
+    UnknownAbility = 18683, // Ally2B->location, no cast, single-target
 }
 
 public enum SID : uint

--- a/BossMod/Modules/Shadowbringers/Alliance/A35XunZiMengZi/A35XunZiMengZi.cs
+++ b/BossMod/Modules/Shadowbringers/Alliance/A35XunZiMengZi/A35XunZiMengZi.cs
@@ -1,5 +1,15 @@
 ﻿namespace BossMod.Shadowbringers.Alliance.A35XunZiMengZi;
 
+class DeployArmaments1(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.DeployArmaments1), new AOEShapeRect(50, 9));
+class DeployArmaments2(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.DeployArmaments2), new AOEShapeRect(50, 9));
+class DeployArmaments3(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.DeployArmaments3), new AOEShapeRect(50, 9));
+class DeployArmaments4(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.DeployArmaments4), new AOEShapeRect(50, 9));
+class DeployArmaments5(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.DeployArmaments5), new AOEShapeRect(50, 9));
+class DeployArmaments6(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.DeployArmaments6), new AOEShapeRect(50, 9));
+class DeployArmaments7(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.DeployArmaments7), new AOEShapeRect(50, 9));
+class DeployArmaments8(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.DeployArmaments8), new AOEShapeRect(50, 9));
+class UniversalAssault(BossModule module) : Components.RaidwideCast(module, ActionID.MakeSpell(AID.UniversalAssault));
+
 [ModuleInfo(BossModuleInfo.Maturity.WIP, Contributors = "The Combat Reborn Team", PrimaryActorOID = (uint)OID.XunZi, GroupType = BossModuleInfo.GroupType.CFC, GroupID = 779, NameID = 9921)]
 public class A35XunZiMengZi(WorldState ws, Actor primary) : BossModule(ws, primary, new(800, 800), new ArenaBoundsSquare(25))
 {

--- a/BossMod/Modules/Shadowbringers/Alliance/A35XunZiMengZi/A35XunZiMengZiEnums.cs
+++ b/BossMod/Modules/Shadowbringers/Alliance/A35XunZiMengZi/A35XunZiMengZiEnums.cs
@@ -14,12 +14,6 @@ public enum OID : uint
 
 public enum AID : uint
 {
-    BladeFlurry1 = 23788, // Ally2B->XunZi, no cast, single-target
-    BladeFlurry2 = 23789, // Ally2B->XunZi, no cast, single-target
-    DancingBlade = 23790, // Ally2B->XunZi, no cast, width 2 rect charge
-    BalancedEdge = 23791, // Ally2B->self, 2.0s cast, range 5 circle
-    WhirlingAssault = 23792, // Ally2B->self, 2.0s cast, range 40 width 4 rect
-
     DeployArmaments1 = 23552, // XunZi/MengZi->self, 6.0s cast, range 50 width 18 rect
     DeployArmaments2 = 23553, // MengZi->self, 7.0s cast, range 50 width 18 rect
     DeployArmaments3 = 23554, // Helper->self, 6.7s cast, range 50 width 18 rect
@@ -32,6 +26,12 @@ public enum AID : uint
     HighPoweredLaser = 23561, // SerialJointedModel->self, no cast, range 70 width 4 rect
     UniversalAssault = 23558, // XunZi/MengZi->self, 5.0s cast, range 50 width 50 rect
     LowPoweredOffensive = 23559, // SmallFlyer->self, 2.0s cast, single-target
+
+    BladeFlurry1 = 23788, // Ally2B->XunZi, no cast, single-target
+    BladeFlurry2 = 23789, // Ally2B->XunZi, no cast, single-target
+    DancingBlade = 23790, // Ally2B->XunZi, no cast, width 2 rect charge
+    BalancedEdge = 23791, // Ally2B->self, 2.0s cast, range 5 circle
+    WhirlingAssault = 23792, // Ally2B->self, 2.0s cast, range 40 width 4 rect
 }
 
 public enum SID : uint

--- a/BossMod/Modules/Shadowbringers/Alliance/A35XunZiMengZi/A35XunZiMengZiStates.cs
+++ b/BossMod/Modules/Shadowbringers/Alliance/A35XunZiMengZi/A35XunZiMengZiStates.cs
@@ -1,8 +1,18 @@
 ﻿namespace BossMod.Shadowbringers.Alliance.A35XunZiMengZi;
+
 class A35XunZiMengZiStates : StateMachineBuilder
 {
     public A35XunZiMengZiStates(BossModule module) : base(module)
     {
-        TrivialPhase();
+        TrivialPhase()
+            //.ActivateOnEnter<DeployArmaments1>() unneeded
+            //.ActivateOnEnter<DeployArmaments2>() unneeded
+            .ActivateOnEnter<DeployArmaments3>()
+            //.ActivateOnEnter<DeployArmaments4>() unneeded
+            //.ActivateOnEnter<DeployArmaments5>() unneeded
+            .ActivateOnEnter<DeployArmaments6>()
+            .ActivateOnEnter<DeployArmaments7>()
+            .ActivateOnEnter<DeployArmaments8>()
+            .ActivateOnEnter<UniversalAssault>();
     }
 }

--- a/BossMod/Modules/Shadowbringers/Alliance/A36FalseIdol/A36FalseIdol.cs
+++ b/BossMod/Modules/Shadowbringers/Alliance/A36FalseIdol/A36FalseIdol.cs
@@ -1,4 +1,10 @@
 ﻿namespace BossMod.Shadowbringers.Alliance.A36FalseIdol;
 
+class MadeMagic1(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.MadeMagic1), new AOEShapeRect(50, 15));
+class MadeMagic2(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.MadeMagic2), new AOEShapeRect(50, 15));
+class ScreamingScore(BossModule module) : Components.RaidwideCast(module, ActionID.MakeSpell(AID.ScreamingScore));
+class ScatteredMagic(BossModule module) : Components.LocationTargetedAOEs(module, ActionID.MakeSpell(AID.ScatteredMagic), 4);
+class DarkerNote2(BossModule module) : Components.SpreadFromCastTargets(module, ActionID.MakeSpell(AID.DarkerNote2), 6);
+
 [ModuleInfo(BossModuleInfo.Maturity.WIP, Contributors = "The Combat Reborn Team", GroupType = BossModuleInfo.GroupType.CFC, GroupID = 779, NameID = 9948)]
 public class A36FalseIdol(WorldState ws, Actor primary) : BossModule(ws, primary, new(-700, -700), new ArenaBoundsSquare(25));

--- a/BossMod/Modules/Shadowbringers/Alliance/A36FalseIdol/A36FalseIdolEnums.cs
+++ b/BossMod/Modules/Shadowbringers/Alliance/A36FalseIdol/A36FalseIdolEnums.cs
@@ -9,26 +9,27 @@ public enum OID : uint
 
 public enum AID : uint
 {
-    BladeFlurry = 23788, // Ally2B->Boss/HerInflorescence, no cast, single-target
-    BladeFlurry2 = 23789, // Ally2B->Boss/HerInflorescence, no cast, single-target
     BossAutoAttack = 24572, // Boss->player, no cast, single-target
-    DancingBlade = 23790, // Ally2B->Boss, no cast, width 2 rect charge
-    BalancedEdge = 23791, // Ally2B->self, 2.0s cast, range 5 circle
-    ScreamingScore = 23517, // Boss->self, 5.0s cast, range 60 circle
+    Eminence = 24021, // Boss->location, 5.0s cast, range 60 circle
+    RhythmRings = 23508, // Boss->self, 3.0s cast, single-target
+    MagicalInterference = 23509, // Helper->self, no cast, range 50 width 10 rect
     MadeMagic1 = 23510, // Boss->self, 7.0s cast, range 50 width 30 rect
-    WhirlingAssault = 23792, // Ally2B->self, 2.0s cast, range 40 width 4 rect
     MadeMagic2 = 23511, // Boss->self, 7.0s cast, range 50 width 30 rect
     LighterNote1 = 23512, // Boss->self, 3.0s cast, single-target
     LighterNote2 = 23513, // Helper->location, no cast, range 6 circle
     LighterNote3 = 23514, // Helper->location, no cast, range 6 circle
-    RhythmRings = 23508, // Boss->self, 3.0s cast, single-target
-    MagicalInterference = 23509, // Helper->self, no cast, range 50 width 10 rect
+    DarkerNote1 = 23515, // Boss->self, 5.0s cast, single-target
+    DarkerNote2 = 23516, // Helper->players, 5.0s cast, range 6 circle
+    ScreamingScore = 23517, // Boss->self, 5.0s cast, range 60 circle
     SeedOfMagic = 23518, // Boss->self, 3.0s cast, single-target
     ScatteredMagic = 23519, // Helper->location, 3.0s cast, range 4 circle
-    DarkerNote1 = 23516, // Helper->players, 5.0s cast, range 6 circle
-    DarkerNote2 = 23515, // Boss->self, 5.0s cast, single-target
+
+    DancingBlade = 23790, // Ally2B->Boss, no cast, width 2 rect charge
+    BalancedEdge = 23791, // Ally2B->self, 2.0s cast, range 5 circle
+    WhirlingAssault = 23792, // Ally2B->self, 2.0s cast, range 40 width 4 rect
     UnknownAbility = 18683, // Ally2B->location, no cast, single-target
-    Eminence = 24021, // Boss->location, 5.0s cast, range 60 circle
+    BladeFlurry = 23788, // Ally2B->Boss/HerInflorescence, no cast, single-target
+    BladeFlurry2 = 23789, // Ally2B->Boss/HerInflorescence, no cast, single-target
 }
 
 public enum SID : uint

--- a/BossMod/Modules/Shadowbringers/Alliance/A36FalseIdol/A36FalseIdolStates.cs
+++ b/BossMod/Modules/Shadowbringers/Alliance/A36FalseIdol/A36FalseIdolStates.cs
@@ -1,8 +1,14 @@
 ﻿namespace BossMod.Shadowbringers.Alliance.A36FalseIdol;
+
 class A36FalseIdolStates : StateMachineBuilder
 {
     public A36FalseIdolStates(BossModule module) : base(module)
     {
-        TrivialPhase();
+        TrivialPhase()
+            //.ActivateOnEnter<MadeMagic1>() not appearing properly
+            //.ActivateOnEnter<MadeMagic2>() not appearing properly
+            .ActivateOnEnter<ScreamingScore>()
+            .ActivateOnEnter<ScatteredMagic>()
+            .ActivateOnEnter<DarkerNote2>();
     }
 }

--- a/BossMod/Modules/Shadowbringers/Alliance/A37HerInfloresence/A37HerInfloresence.cs
+++ b/BossMod/Modules/Shadowbringers/Alliance/A37HerInfloresence/A37HerInfloresence.cs
@@ -1,4 +1,15 @@
 ﻿namespace BossMod.Shadowbringers.Alliance.A37HerInfloresence;
 
+class UnevenFooting(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.UnevenFooting), new AOEShapeRect(80, 15, 80));
+class Crash(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.Crash), new AOEShapeRect(50, 5));
+class ScreamingScore(BossModule module) : Components.RaidwideCast(module, ActionID.MakeSpell(AID.ScreamingScore));
+class DarkerNote1(BossModule module) : Components.SpreadFromCastTargets(module, ActionID.MakeSpell(AID.DarkerNote1), 6);
+class HeavyArms1(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.HeavyArms1), new AOEShapeRect(44, 50, -5));
+class HeavyArms3(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.HeavyArms3), new AOEShapeRect(100, 6, 100));
+class PlaceOfPower(BossModule module) : Components.LocationTargetedAOEs(module, ActionID.MakeSpell(AID.PlaceOfPower), 6);
+class Shockwave1(BossModule module) : Components.KnockbackFromCastTarget(module, ActionID.MakeSpell(AID.Shockwave1), 35);
+class Shockwave2(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.Shockwave2), new AOEShapeCircle(7));
+class Towerfall2(BossModule module) : Components.SelfTargetedAOEs(module, ActionID.MakeSpell(AID.Towerfall2), new AOEShapeRect(70, 7));
+
 [ModuleInfo(BossModuleInfo.Maturity.WIP, Contributors = "The Combat Reborn Team", GroupType = BossModuleInfo.GroupType.CFC, GroupID = 779, NameID = 9949)]
 public class A37HerInfloresence(WorldState ws, Actor primary) : BossModule(ws, primary, new(-700, -700), new ArenaBoundsSquare(25));

--- a/BossMod/Modules/Shadowbringers/Alliance/A37HerInfloresence/A37HerInfloresenceEnums.cs
+++ b/BossMod/Modules/Shadowbringers/Alliance/A37HerInfloresence/A37HerInfloresenceEnums.cs
@@ -11,45 +11,66 @@ public enum OID : uint
 
 public enum AID : uint
 {
-    BladeFlurry1 = 23788, // Ally2B->Boss, no cast, single-target
-    BladeFlurry2 = 23789, // Ally2B->Boss, no cast, single-target
     BossAutoAttack = 24575, // Boss->player, no cast, single-target
-    DancingBlade = 23790, // Ally2B->Boss, no cast, width 2 rect charge
+
+    // Building through floor mechanic
     Pervasion = 23520, // Boss->self, 3.0s cast, single-target
-    BalancedEdge = 23791, // Ally2B->self, 2.0s cast, range 5 circle
     RecreateStructure = 23521, // Boss->self, 3.0s cast, single-target
-    UnknownAbility1 = 18683, // Ally2B->location, no cast, single-target
     UnevenFooting = 23522, // Helper->self, 1.9s cast, range 80 width 30 rect
+
+    // Train mechanic
     RecreateSignal = 23523, // Boss->self, 3.0s cast, single-target
     MixedSignals = 23524, // Boss->self, 3.0s cast, single-target
     Crash = 23525, // Helper->self, 0.8s cast, range 50 width 10 rect
+
+    // Player baited marching AOEs
     LighterNote1 = 23564, // Boss->self, 3.0s cast, single-target
     LighterNote2 = 23513, // Helper->location, no cast, range 6 circle
     LighterNote3 = 23514, // Helper->location, no cast, range 6 circle
+
+    // Raidwide
     ScreamingScore = 23541, // Boss->self, 5.0s cast, range 71 circle
-    WhirlingAssault = 23792, // Ally2B->self, 2.0s cast, range 40 width 4 rect
+
+    // all three tanks get a pink AoE damage marker
     DarkerNote1 = 23516, // Helper->player, 5.0s cast, range 6 circle
     DarkerNote2 = 23562, // Boss->self, 5.0s cast, single-target
+
+    // Boss forms arms into pillars and signals where they will fall, to her flanks or front and rear
     HeavyArms1 = 23535, // Helper->self, 7.0s cast, range 44 width 100 rect
     HeavyArms2 = 23534, // Boss->self, 7.0s cast, single-target
     HeavyArms3 = 23533, // Boss->self, 7.0s cast, range 100 width 12 rect
+
+    // players get a circle surrounding them - half white/half black - likely going to need to be similar to gaze code
+    // a large ring will start to drop in the center
+    // you need to match your half of color to it to avoid damage
     Distortion1 = 23529, // Boss->self, 3.0s cast, range 60 circle
+    Distortion2 = 24664, // Boss->self, 3.0s cast, range 60 circle
     TheFinalSong = 23530, // Boss->self, 3.0s cast, single-target
-    PlaceOfPower = 23565, // Helper->location, 3.0s cast, range 6 circle
     WhiteDissonance = 23531, // Helper->self, no cast, range 60 circle
     BlackDissonance = 23532, // Helper->self, no cast, range 60 circle
-    PillarImpact1 = 23536, // Boss->self, 10.0s cast, single-target
-    Shockwave1 = 23538, // Helper->self, 6.5s cast, range 71 circle
+    PlaceOfPower = 23565, // Helper->location, 3.0s cast, range 6 circle
+
+    PillarImpact1 = 23566, // Boss->self, no cast, single-target
+    PillarImpact2 = 23536, // Boss->self, 10.0s cast, single-target
+    Shockwave1 = 23538, // Helper->self, 6.5s cast, range 71 circle knockback 35
     Shockwave2 = 23537, // Helper->self, 6.5s cast, range 7 circle
-    PillarImpact2 = 23566, // Boss->self, no cast, single-target
     Towerfall1 = 23539, // Boss->self, 3.0s cast, single-target
     Towerfall2 = 23540, // Helper->self, 3.0s cast, range 70 width 14 rect
+
     UnknownAbility2 = 23526, // RedGirl->self, no cast, single-target
-    Distortion2 = 24664, // Boss->self, 3.0s cast, range 60 circle
-    ScatteredMagic = 23528, // Energy->player, no cast, single-target
     UnknownAbility3 = 23527, // RedGirl->self, no cast, single-target
+    ScatteredMagic = 23528, // Energy->player, no cast, single-target
+
+    // Beams firing across the arena - need to figure out indicators
     RhythmRings = 23563, // Boss->self, 3.0s cast, single-target
     MagicalInterference = 23509, // Helper->self, no cast, range 50 width 10 rect
+
+    BladeFlurry1 = 23788, // Ally2B->Boss, no cast, single-target
+    BladeFlurry2 = 23789, // Ally2B->Boss, no cast, single-target
+    DancingBlade = 23790, // Ally2B->Boss, no cast, width 2 rect charge
+    BalancedEdge = 23791, // Ally2B->self, 2.0s cast, range 5 circle
+    UnknownAbility1 = 18683, // Ally2B->location, no cast, single-target
+    WhirlingAssault = 23792, // Ally2B->self, 2.0s cast, range 40 width 4 rect
 }
 
 public enum SID : uint

--- a/BossMod/Modules/Shadowbringers/Alliance/A37HerInfloresence/A37HerInfloresenceStates.cs
+++ b/BossMod/Modules/Shadowbringers/Alliance/A37HerInfloresence/A37HerInfloresenceStates.cs
@@ -4,6 +4,16 @@ class A37HerInfloresenceStates : StateMachineBuilder
 {
     public A37HerInfloresenceStates(BossModule module) : base(module)
     {
-        TrivialPhase();
+        TrivialPhase()
+            .ActivateOnEnter<UnevenFooting>()
+            .ActivateOnEnter<Crash>()
+            .ActivateOnEnter<ScreamingScore>()
+            .ActivateOnEnter<DarkerNote1>()
+            .ActivateOnEnter<HeavyArms1>()
+            .ActivateOnEnter<HeavyArms3>()
+            .ActivateOnEnter<PlaceOfPower>()
+            .ActivateOnEnter<Shockwave1>()
+            .ActivateOnEnter<Shockwave2>()
+            .ActivateOnEnter<Towerfall2>();
     }
 }


### PR DESCRIPTION
Updated various files to introduce new AOE attack classes and mechanics:
- `A13Engels.cs`: Added new AOE classes and updated `A13MarxEngels`.
- `A13EngelsEnums.cs`: Added and re-ordered AIDs.
- `A13EngelsStates.cs`: Activated new components in `TrivialPhase`.
- `A34RedGirlP1.cs`: Added `DiffuseEnergy1` class.
- `A34RedGirlP1States.cs`: Activated `ShockWhite2` and `ShockBlack2`.
- `A34RedGirlP2Enums.cs`: Added new AIDs.
- `A35XunZiMengZi.cs`: Added new AOE classes.
- `A35XunZiMengZiEnums.cs`: Added new AIDs.
- `A35XunZiMengZiStates.cs`: Activated new components in `TrivialPhase`.
- `A36FalseIdol.cs`: Added new boss mechanics classes.
- `A36FalseIdolEnums.cs`: Updated abilities.
- `A36FalseIdolStates.cs`: Modified `TrivialPhase` mechanics.
- `A37HerInfloresence.cs`: Added new boss mechanics classes.
- `A37HerInfloresenceEnums.cs`: Updated abilities.
- `A37HerInfloresenceStates.cs`: Modified `TrivialPhase` mechanics.