### PR TITLE
M5S Dancing Green: Improve Wavelength Alpha/Beta hints

### DIFF
--- a/BossMod/Modules/Dawntrail/Savage/M05SDancingGreen/WavelengthAlphaBeta.cs
+++ b/BossMod/Modules/Dawntrail/Savage/M05SDancingGreen/WavelengthAlphaBeta.cs
@@ -1,37 +1,60 @@
+using BossMod.Global.MaskedCarnivale.Stage01;
+
 namespace BossMod.Dawntrail.Savage.M05SDancingGreen;
 
 class WavelengthAlphaBeta(BossModule module) : BossComponent(module)
 {
-    private readonly (DateTime Expiration, Actor Actor, DateTime ExpirationReal)[] expirationBySlot = new (DateTime, Actor, DateTime)[8]; // first expiration is rounded to find matching partner more easily
+    private class PlayerInfo
+    {
+        public Actor Actor;
+        public DateTime Expiration;  // rounded for matching
+        public DateTime ExpirationReal;
+        public uint StatusID;
+        public int Order;  // 1-4, where 1 is the shortest time
+    }
+
+    private readonly PlayerInfo[] playersBySlot = new PlayerInfo[8];
     private int numCasts;
+    private bool orderDetermined;
 
     public override void AddHints(int slot, Actor actor, TextHints hints)
     {
         if (numCasts == 8)
         {
-            ref readonly var player = ref expirationBySlot[slot];
+            var player = playersBySlot[slot];
+            if (player == null)
+                return;
 
-            bool? inRisk = null;
-            for (var i = 0; i < 8; ++i)
+            var partner = FindPartner(slot, player);
+            if (partner != null)
             {
-                ref readonly var exp = ref expirationBySlot[i];
-                if (exp == default || slot == i)
-                    continue;
-                var remaining = Math.Max(0d, (exp.ExpirationReal - WorldState.CurrentTime).TotalSeconds);
+                var remaining = Math.Max(0d, (partner.ExpirationReal - WorldState.CurrentTime).TotalSeconds);
                 var check = remaining < 5d;
-                var partner = exp.Actor;
-                if (exp.Expiration == player.Expiration)
+                hints.Add($"Order: {player.Order}");
+                hints.Add($"Stack with: {partner.Actor.Name} (#{player.Order}) in {remaining:f0}s", check);
+
+                // Check for incorrect stacks
+                bool inRisk = false;
+                for (var i = 0; i < 8; ++i)
                 {
-                    hints.Add($"Stack with: {partner.Name} in {remaining:f0}s", check);
-                }
-                else if (check)
-                {
-                    if (actor.Position.InCircle(partner.Position, 2f))
+                    var other = playersBySlot[i];
+                    if (other == null || i == slot || other == partner)
+                        continue;
+
+                    var otherRemaining = Math.Max(0d, (other.ExpirationReal - WorldState.CurrentTime).TotalSeconds);
+                    if (otherRemaining < 5d && actor.Position.InCircle(other.Actor.Position, 2f))
+                    {
                         inRisk = true;
+                    }
                 }
+
+                if (inRisk)
+                    hints.Add("GTFO from incorrect stacks!");
             }
-            if (inRisk != null)
-                hints.Add($"GTFO from incorrect stacks!");
+            else
+            {
+                hints.Add("No viable partner found!");
+            }
         }
     }
 
@@ -39,27 +62,39 @@ class WavelengthAlphaBeta(BossModule module) : BossComponent(module)
     {
         if (numCasts == 8)
         {
-            ref readonly var player = ref expirationBySlot[pcSlot].Expiration;
+            var player = playersBySlot[pcSlot];
+            if (player == null)
+            {
+                return;
+            }
+
+            var partner = FindPartner(pcSlot, player);
             for (var i = 0; i < 8; ++i)
             {
-                ref readonly var exp = ref expirationBySlot[i];
-                if (exp == default || pcSlot == i)
+                var other = playersBySlot[i];
+                if (other == null || i == pcSlot)
                     continue;
-                var remaining = Math.Max(0d, (exp.ExpirationReal - WorldState.CurrentTime).TotalSeconds) < 5d;
-                var partner = exp.Actor;
-                if (!remaining)
+
+                var remaining = Math.Max(0d, (other.ExpirationReal - WorldState.CurrentTime).TotalSeconds);
+                if (remaining >= 5d)
                     continue;
-                if (exp.Expiration == player)
+
+                // partner
+                if (partner != null && other == partner)
                 {
-                    Arena.AddCircle(partner.Position, 2f, Colors.Safe);
+                    var color = pc.Position.InCircle(other.Actor.Position, 2f) ? Colors.Safe : Colors.Danger;
+                    Arena.AddCircle(other.Actor.Position, 2f, color);
                 }
-                else
+
+                // intersecting wrong player
+                if (pc.Position.InCircle(other.Actor.Position, 2f))
                 {
-                    Arena.AddCircle(partner.Position, 2f);
+                    Arena.AddCircle(other.Actor.Position, 2f, Colors.Danger);
                 }
             }
         }
     }
+
     public override void OnStatusGain(Actor actor, ActorStatus status)
     {
         if (status.ID is (uint)SID.WavelengthAlpha or (uint)SID.WavelengthBeta)
@@ -67,7 +102,15 @@ class WavelengthAlphaBeta(BossModule module) : BossComponent(module)
             var slot = WorldState.Party.FindSlot(actor.InstanceID);
             if (slot < 0)
                 return;
-            expirationBySlot[slot] = (status.ExpireAt.Round(TimeSpan.FromSeconds(1d)), actor, status.ExpireAt);
+
+            playersBySlot[slot] = new PlayerInfo
+            {
+                Actor = actor,
+                Expiration = status.ExpireAt.Round(TimeSpan.FromSeconds(1d)),
+                ExpirationReal = status.ExpireAt,
+                StatusID = status.ID,
+                Order = 0
+            };
         }
     }
 
@@ -78,13 +121,103 @@ class WavelengthAlphaBeta(BossModule module) : BossComponent(module)
             var slot = WorldState.Party.FindSlot(actor.InstanceID);
             if (slot < 0)
                 return;
-            expirationBySlot[slot] = default;
+
+            if (playersBySlot[slot] != null)
+            {
+                playersBySlot[slot].ExpirationReal = DateTime.MinValue;
+            }
         }
     }
 
     public override void OnEventCast(Actor caster, ActorCastEvent spell)
     {
         if (spell.Action.ID == (uint)AID.GetDownBait)
+        {
             ++numCasts;
+
+            // determine debuff order after all 8 casts
+            if (numCasts == 8 && !orderDetermined)
+            {
+                DetermineOrder();
+                orderDetermined = true;
+            }
+        }
+    }
+
+    private void DetermineOrder()
+    {
+        // group players by debuff
+        var alphaPlayers = new List<PlayerInfo>();
+        var betaPlayers = new List<PlayerInfo>();
+
+        foreach (var player in playersBySlot)
+        {
+            if (player == null)
+                continue;
+
+            if (player.StatusID == (uint)SID.WavelengthAlpha)
+            {
+                alphaPlayers.Add(player);
+            }
+            else
+            {
+                betaPlayers.Add(player);
+            }
+        }
+
+        // sort each debuff group by expiration time
+        alphaPlayers.Sort((a, b) => a.Expiration.CompareTo(b.Expiration));
+        betaPlayers.Sort((a, b) => a.Expiration.CompareTo(b.Expiration));
+
+        // assign order from 1-4
+        for (int index = 0; index < alphaPlayers.Count; index++)
+        {
+            alphaPlayers[index].Order = index + 1;
+        }
+
+        for (int index = 0; index < betaPlayers.Count; index++)
+        {
+            betaPlayers[index].Order = index + 1;
+        }
+    }
+
+    private PlayerInfo FindPartner(int slot, PlayerInfo player)
+    {
+        PlayerInfo bestMatch = null;
+        TimeSpan smallestDiff = TimeSpan.MaxValue;
+
+        // look for the player with opposite debuff and closest expiration time
+        foreach (var other in playersBySlot)
+        {
+            if (other == null || other.Actor.InstanceID == player.Actor.InstanceID) 
+                continue;
+
+            // skip dead players or those with expired debuffs
+            if (!other.Actor.IsTargetable || other.ExpirationReal <= WorldState.CurrentTime) 
+                continue;
+
+            // check if opposite debuff
+            bool isOpposite = (player.StatusID == (uint)SID.WavelengthAlpha && other.StatusID == (uint)SID.WavelengthBeta) ||
+                             (player.StatusID == (uint)SID.WavelengthBeta && other.StatusID == (uint)SID.WavelengthAlpha);
+
+            if (isOpposite)
+            {
+                // check if times are close
+                var timeDiff = player.Expiration - other.Expiration;
+                if (timeDiff < TimeSpan.Zero)
+                {
+                    timeDiff = -timeDiff;
+                }
+
+                // the correct debuff never seems to be more than 3 seconds apart
+                if (timeDiff < smallestDiff && timeDiff.TotalSeconds < 3.0f)
+                {
+                    smallestDiff = timeDiff;
+                    bestMatch = other;
+                }
+            }
+        }
+
+        return bestMatch;
     }
 }


### PR DESCRIPTION
I noticed the hints for this mechanic weren't super useful in this module, so I made it try to determine the player's partner order.
This is more useful for the two prominent strategies for this mechanics:
- Line up from shortest to longest. Knowing the order will allow the player to determine the correct location to stand without second guessing
- Move under the boss at 3 seconds. Knowing the order will allow the player to count when they should move, instead of staring at their debuff timer.

I'm not sure my approach is perfect, you may be able to determine the order from the initial timer values (or the actual order the players got hit?), but I didn't have the time to check that on numerous pulls for validity.
Additionally, if any players enter the mechanic without the debuff, the player who would be their partner cannot succeed and will suffer both the bleed and the lack of Perfect Groove.