### PR TITLE
Reduced standard and technical step drift

### DIFF
--- a/BossMod/Autorotation/Standard/xan/Ranged/DNC.cs
+++ b/BossMod/Autorotation/Standard/xan/Ranged/DNC.cs
@@ -141,7 +141,7 @@ public sealed class DNC(RotationModuleManager manager, Actor player) : Attackxan
             return;
         }
 
-        if (ShouldTechStep(strategy) && ReadyIn(AID.TechnicalStep) <= GCD)
+        if (ShouldTechStep(strategy) && ReadyIn(AID.TechnicalStep) <= GCDLength)
             PushGCD(AID.TechnicalStep, Player);
 
         var shouldStdStep = ShouldStdStep(strategy);
@@ -162,6 +162,9 @@ public sealed class DNC(RotationModuleManager manager, Actor player) : Attackxan
         if (canSymmetry && SymmetryLeft <= GCDLength)
             PushGCD(symmetryCombo, primaryTarget);
 
+        if (FinishingMoveLeft > GCDLength && NumDanceTargets > 0)
+            PushGCD(AID.FinishingMove, Player);
+
         if (DanceOfTheDawnLeft > GCD && Esprit >= 50)
             PushGCD(AID.DanceOfTheDawn, BestRangedAOETarget);
 
@@ -171,9 +174,6 @@ public sealed class DNC(RotationModuleManager manager, Actor player) : Attackxan
         // TODO combine this with above
         if (canStarfall)
             PushGCD(AID.StarfallDance, BestStarfallTarget);
-
-        if (FinishingMoveLeft > GCD && NumDanceTargets > 0)
-            PushGCD(AID.FinishingMove, Player);
 
         if (LastDanceLeft > GCD)
             PushGCD(AID.LastDance, BestRangedAOETarget);
@@ -253,7 +253,7 @@ public sealed class DNC(RotationModuleManager manager, Actor player) : Attackxan
 
     private bool ShouldStdStep(StrategyValues strategy)
     {
-        if (ReadyIn(AID.StandardStep) > GCD)
+        if (ReadyIn(AID.StandardStep) > GCDLength)
             return false;
 
         var stdFinishCast = GCD + 3.5f;


### PR DESCRIPTION
Reduces the drifting of steps if the GCDs are slightly delayed, for example because of latency, at the cost of a few milliseconds of GCD uptime. Maintaining a consistent 2 minute raidbuff window is crucial for high-end content, so the technical part is especially important.

With these changes, the auto rotation will simply wait if it cannot fit another GCD between the upcoming one and the standard/technical step.

Additionally, increased priority on finishing move since that is one of the highest damage GCDs and is tied to the standard step cooldown.

Note that this PR does not fix devilment drifting which is caused by late weaving.