### PR TITLE
Boss 1 beam signaling, hints while beam exists, set 'stay' a little b…

### DIFF
--- a/BossMod/Modules/Dawntrail/Dungeon/D13TheClyteum/D131EyeoftheScorpion.cs
+++ b/BossMod/Modules/Dawntrail/Dungeon/D13TheClyteum/D131EyeoftheScorpion.cs
@@ -1,4 +1,7 @@
-﻿namespace BossMod.Dawntrail.Dungeon.D13TheClyteum.D131EyeOfTheScorpion;
+﻿using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using TerraFX.Interop.Windows;
+
+namespace BossMod.Dawntrail.Dungeon.D13TheClyteum.D131EyeOfTheScorpion;
 
 public enum OID : uint
 {
@@ -48,6 +51,7 @@ sealed class AntiPersonnelMissile(BossModule module) : Components.SpreadFromCast
 
 sealed class MotionTracker(BossModule module) : Components.StayMove(module)
 {
+    public Actor? TrackingBeam;
     public override void OnStatusGain(Actor actor, ref ActorStatus status)
     {
         if (status.ID == (uint)SID.MotionTracker && Raid.FindSlot(actor.InstanceID) is var slot && slot >= 0)
@@ -63,6 +67,41 @@ sealed class MotionTracker(BossModule module) : Components.StayMove(module)
             PlayerStates[slot] = default;
         }
     }
+
+    public override void OnActorRenderflagsChange(Actor actor, int renderflags)
+    {
+        if (renderflags == 0 && actor.OID == (uint)OID.MotionScanner)
+        {
+            TrackingBeam = actor;
+        }
+        if (renderflags == 16384 && actor.OID == (uint)OID.MotionScanner)
+        {
+            TrackingBeam = null;
+        }
+    }
+
+    public override void DrawArenaBackground(int pcSlot, Actor pc)
+    {
+        if (TrackingBeam != null)
+        {
+            var _rect = new AOEShapeRect(9f, 20f, 9f);
+            _rect.Draw(Arena, TrackingBeam.Position, TrackingBeam.Rotation);
+            if (pc.Position.InRect(TrackingBeam.Position, TrackingBeam.Rotation, 9f, 9f, 20f))
+            {
+                PlayerStates[pcSlot] = new(Requirement.Stay, WorldState.CurrentTime);
+            }
+            else
+                PlayerStates[pcSlot] = default; // In theory the status should have fallen off by this point but better safe than sorry.
+        }
+    }
+    public override void AddHints(int slot, Actor actor, TextHints hints)
+    {
+        if (TrackingBeam != null)
+        {
+            hints.Add("Stop everything while in beam!");
+        }
+    }
+
     //TODO: Figure out best way to display the beam.  This works but doesn't communicate very well to the player what should happen. Likely a voidzone on the actor with a hint?
 }
 


### PR DESCRIPTION
Boss 1 beam signaling, hints while beam exists, set 'stay' a little before beam actually hits -- Displayed beam is deliberately wider to try to help BMR 'notice' in time.