### PR TITLE
feat(ipc): Expose additional AIHints and AI navigation state endpoints

### DIFF
--- a/BossMod/Framework/IPCProvider.cs
+++ b/BossMod/Framework/IPCProvider.cs
@@ -1,4 +1,4 @@
-﻿using BossMod.AI;
+using BossMod.AI;
 using BossMod.Autorotation;
 using BossMod.Pathfinding;
 using System.IO;
@@ -135,6 +135,28 @@ sealed class IPCProvider : IDisposable
             var predicted = hints.PredictedDamage;
             return predicted.Count == 0 ? 0 : (int)predicted[0].Type;
         });
+
+        // --- Custom OmniDuty Endpoints ---
+        Register("Hints.MaxCastTime", () => hints.MaxCastTime);
+        Register("Hints.ForceCancelCast", () => hints.ForceCancelCast);
+        Register("Hints.ForbiddenZonesCount", () => hints.ForbiddenZones.Count);
+        Register("Hints.ForbiddenZonesNextActivation", () => hints.ForbiddenZones.Count == 0 ? float.MaxValue : (float)(hints.ForbiddenZones[0].activation - DateTime.Now).TotalSeconds);
+        Register("Hints.ArenaCenter", () => new System.Numerics.Vector2(hints.PathfindMapCenter.X, hints.PathfindMapCenter.Z));
+        Register("Hints.ArenaRadius", () => hints.PathfindMapBounds.Radius);
+        Register("Hints.PredictedDamagePlayers", () => hints.PredictedDamage.Count == 0 ? 0ul : hints.PredictedDamage[0].Players.Raw);
+        Register("Hints.ForbiddenDirectionsCount", () => hints.ForbiddenDirections.Count);
+        Register("Hints.ShouldCleansePlayers", () => hints.ShouldCleanse.Raw);
+        Register("Hints.InteractWithTargetOID", () => hints.InteractWithTarget?.InstanceID ?? 0ul);
+        Register("Hints.RecommendedPositional", () => (int)hints.RecommendedPositional.Pos);
+        Register("AI.PauseMovement", (bool pause) => Service.Config.Get<AI.AIConfig>().ForbidMovement = pause);
+        Register("AI.NaviTargetPos", () =>
+        {
+            var pos = ai.Controller.NaviTargetPos;
+            return pos.HasValue ? new System.Numerics.Vector3(pos.Value.X, 0, pos.Value.Z) : (System.Numerics.Vector3?)null;
+        });
+        Register("AI.IsNavigating", () => ai.Controller.NaviTargetPos != null);
+        Register("AI.PlayerSpeed", () => ai.WorldState.Client.MoveSpeed);
+        // ---------------------------------
 
         // Type-specific damage prediction endpoints — search ALL entries for the first matching type
         Register("Hints.NextRaidwideDamageIn", () =>


### PR DESCRIPTION
**What does this PR do?**
This PR extends the IPCProvider.cs to expose several existing AIHints and AIController variables that are highly valuable for external plugins seeking to build custom combat routines or overlays.

Currently, BMR exposes timeline events and some basic hints, but crucial spatial data (arena bounds, forbidden zones) and AI intent (navigation targets, recommended positionals) remain locked internally.

**Endpoints Added:**
*   Hints.MaxCastTime (float): Maximum time a player can cast before needing to move.
*   Hints.ForceCancelCast (bool): Signals if the current cast must be immediately aborted.
*   Hints.ForbiddenZonesCount (int): Number of active forbidden zones.
*   Hints.ForbiddenZonesNextActivation (float): Seconds until the nearest zone activates.
*   Hints.ArenaCenter (Vector2): Center coordinates of the current Pathfind map.
*   Hints.ArenaRadius (float): Radius of the current Pathfind map.
*   Hints.PredictedDamagePlayers (ulong): Bitmask of players affected by the next predicted damage.
*   Hints.ForbiddenDirectionsCount (int): Active gaze/directional hazards.
*   Hints.ShouldCleansePlayers (ulong): Bitmask of players that require Esuna.
*   Hints.InteractWithTargetOID (ulong): Object ID of the target the AI wants to interact with.
*   Hints.RecommendedPositional (int):  =Any, 1=Flank, 2=Rear, 3=Front.
*   AI.PauseMovement (Action<bool>): Toggle to programmatically forbid BMR movement.
*   AI.NaviTargetPos (Vector3?): The current destination the AI is pathfinding towards.
*   AI.IsNavigating (bool): True if the AI has an active navigation target.
*   AI.PlayerSpeed (float): The current movement speed of the player.

**Why is this needed?**
External healing or mitigation engines need to know *when* they are forced to move (MaxCastTime, ForceCancelCast) to implement slidecasting greed logic. Additionally, exposing ShouldCleansePlayers allows external plugins to trigger Esuna efficiently without recalculating debuff logic. Exposing NaviTargetPos allows 3D overlays to draw the path BMR is taking.

**Impact:**
*   **Zero overhead:** Only registers delegates during IPC initialization. No per-frame performance impact.
*   **Non-breaking:** Simply adds new registered strings, does not modify any existing BossMod behavior or API signatures.
