### PR TITLE
Ex8 - Gaze of the Void Orbs, Vacuum added

### DIFF
--- a/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8Enuo.cs
+++ b/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8Enuo.cs
@@ -2,7 +2,36 @@
 
 sealed class Meteorain(BossModule module) : Components.RaidwideCast(module, (uint)AID.Meteorain);
 
-sealed class GazeOfTheVoidAOE(BossModule module) : Components.SimpleAOEs(module, (uint)AID.GazeOfTheVoid2, new AOEShapeCone(40f, 22.5f.Degrees()), 7);
+sealed class VacuumAOE(BossModule module) : Components.Voidzone(module, 7f, FindVacuums)
+{
+    private static Actor[] FindVacuums(BossModule module)
+    {
+        var enemies = module.Enemies((uint)OID.VoidVacuum);
+        var count = enemies.Count;
+        if (count == 0)
+        {
+            return [];
+        }
+        var vacs = new Actor[count];
+        var index = 0;
+        for (var i = 0; i < enemies.Count; i++)
+        {
+            var z = enemies[i];
+            // These appear at the start of the mechanic at Arena.Center and zoom out to their final locations, we only care about showing them while they're standing still and not in the Center. They die after exploding.
+            if (z.Renderflags == 0 && !z.Position.AlmostEqual(module.Arena.Center, 2f) && z.LastFrameMovement == new WDir(0f, 0f))
+            {
+                vacs[index++] = z;
+            }
+        }
+        return vacs[..index];
+    }
+}
+
+sealed class VacuumArc1(BossModule module) : Components.SimpleAOEs(module, (uint)AID.SilentTorrentArc1, new AOEShapeDonutSector(17f, 19f, 20f.Degrees()));
+
+sealed class VacuumArc2(BossModule module) : Components.SimpleAOEs(module, (uint)AID.SilentTorrentArc2, new AOEShapeDonutSector(17f, 19f, 30f.Degrees()));
+
+sealed class VacuumArc3(BossModule module) : Components.SimpleAOEs(module, (uint)AID.SilentTorrentArc3, new AOEShapeDonutSector(17f, 19f, 10f.Degrees()));
 
 sealed class ArenaChanges(BossModule module) : BossComponent(module)
 {

--- a/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8Enuo.cs
+++ b/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8Enuo.cs
@@ -32,6 +32,7 @@ sealed class VacuumArc1(BossModule module) : Components.SimpleAOEs(module, (uint
 sealed class VacuumArc2(BossModule module) : Components.SimpleAOEs(module, (uint)AID.SilentTorrentArc2, new AOEShapeDonutSector(17f, 19f, 30f.Degrees()));
 
 sealed class VacuumArc3(BossModule module) : Components.SimpleAOEs(module, (uint)AID.SilentTorrentArc3, new AOEShapeDonutSector(17f, 19f, 10f.Degrees()));
+sealed class VacuumTelegraph(BossModule module) : Components.SimpleAOEGroups(module, [(uint)AID.SilentTorrentDash, (uint)AID.SilentTorrentDash2, (uint)AID.SilentTorrentDash3], new AOEShapeCircle(7f));
 
 sealed class ArenaChanges(BossModule module) : BossComponent(module)
 {

--- a/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8Enuo.cs
+++ b/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8Enuo.cs
@@ -34,6 +34,36 @@ sealed class VacuumArc2(BossModule module) : Components.SimpleAOEs(module, (uint
 sealed class VacuumArc3(BossModule module) : Components.SimpleAOEs(module, (uint)AID.SilentTorrentArc3, new AOEShapeDonutSector(17f, 19f, 10f.Degrees()));
 sealed class VacuumTelegraph(BossModule module) : Components.SimpleAOEGroups(module, [(uint)AID.SilentTorrentDash, (uint)AID.SilentTorrentDash2, (uint)AID.SilentTorrentDash3], new AOEShapeCircle(7f));
 
+sealed class DeepFreezeFlares(BossModule module) : Components.SpreadFromCastTargets(module, (uint)AID.DeepFreeze, 10f);
+
+sealed class DeepFreeze(BossModule module) : Components.StayMove(module)
+{
+    public override void OnCastStarted(Actor caster, ActorCastInfo spell)
+    {
+        if (spell.Action.ID == (uint)AID.DeepFreeze)
+        {
+            for (var i = 0; i < PlayerStates.Length; i++)
+            {
+                PlayerStates[i] = new(Requirement.Move, WorldState.FutureTime(spell.RemainingTime));
+            }
+        }
+    }
+    public override void OnStatusGain(Actor actor, ref ActorStatus status)
+    {
+        if (status.ID == (uint)SID.FreezingUp)
+        {
+            PlayerStates[Raid.FindSlot(actor.InstanceID)] = new(Requirement.Move, WorldState.CurrentTime, finish: status.ExpireAt);
+        }
+    }
+    public override void OnStatusLose(Actor actor, ref ActorStatus status)
+    {
+        if (status.ID == (uint)SID.FreezingUp)
+        {
+            PlayerStates[Raid.FindSlot(actor.InstanceID)] = default;
+        }
+    }
+}
+
 sealed class ArenaChanges(BossModule module) : BossComponent(module)
 {
 

--- a/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8EnuoEnums.cs
+++ b/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8EnuoEnums.cs
@@ -11,9 +11,9 @@ public enum OID : uint
     Unknown = 0x4DB8, // R5.000, x2
     Void = 0x4BFA, // R2.000, x0 (spawn during fight), Helper type
     Void1 = 0x4BF7, // R1.000, x0 (spawn during fight), Helper type
-    Void2 = 0x4DC5, // R0.850, x0 (spawn during fight)
-    Void3 = 0x4DC6, // R1.750, x0 (spawn during fight)
-    Void4 = 0x4DC4, // R0.850, x0 (spawn during fight), Helper type
+    VoidSoakSmall = 0x4DC5, // R0.850, x0 (spawn during fight)
+    VoidSoakLarge = 0x4DC6, // R1.750, x0 (spawn during fight)
+    VoidVacuum = 0x4DC4, // R0.850, x0 (spawn during fight), Helper type
     AggressiveShadow = 0x4DC9, // R5.000, x0 (spawn during fight)
     SoothingShadow = 0x4DCA, // R5.000, x0 (spawn during fight)
     ProtectiveShadow = 0x4DC8, // R5.000, x0 (spawn during fight)
@@ -49,10 +49,10 @@ public enum AID : uint
     SilentTorrent = 49996, // 4DC4->location, 3.5s cast, single-target
     SilentTorrent1 = 49997, // 4DC4->location, 3.5s cast, single-target
     SilentTorrent2 = 49995, // 4DC4->location, 3.5s cast, single-target
-    SilentTorrent3 = 49999, // 233C->self, 4.0s cast, range ?-19 donut
-    SilentTorrent4 = 50000, // 233C->self, 4.0s cast, range ?-19 donut
-    SilentTorrent5 = 49998, // 233C->self, 4.0s cast, range ?-19 donut
-    Vacuum1 = 50001, // 4DC4->self, 1.5s cast, range 7 circle
+    SilentTorrentArc1 = 49999, // 233C->self, 4.0s cast, range ?-19 donut
+    SilentTorrentArc2 = 50000, // 233C->self, 4.0s cast, range ?-19 donut
+    SilentTorrentArc3 = 49998, // 233C->self, 4.0s cast, range ?-19 donut
+    VacuumExplode = 50001, // 4DC4->self, 1.5s cast, range 7 circle
     DenseEmptiness = 50033, // 4DC1->self, 4.0+1.0s cast, single-target
     DenseEmptiness1 = 50035, // 233C->self, no cast, range 60 ?-degree cone
     DeepFreeze = 50043, // 4DC1->self, 5.0+1.0s cast, range 40 circle

--- a/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8EnuoEnums.cs
+++ b/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8EnuoEnums.cs
@@ -46,9 +46,9 @@ public enum AID : uint
     Burst = 50006, // 4DC5->self, no cast, range 5 circle
     ViolentBurst = 50007, // 4DC6->self, no cast, range 6 circle
     Vacuum = 49994, // 4DC1->self, 2.0+1.0s cast, single-target
-    SilentTorrent = 49996, // 4DC4->location, 3.5s cast, single-target
-    SilentTorrent1 = 49997, // 4DC4->location, 3.5s cast, single-target
-    SilentTorrent2 = 49995, // 4DC4->location, 3.5s cast, single-target
+    SilentTorrentDash = 49996, // 4DC4->location, 3.5s cast, single-target
+    SilentTorrentDash2 = 49997, // 4DC4->location, 3.5s cast, single-target
+    SilentTorrentDash3 = 49995, // 4DC4->location, 3.5s cast, single-target
     SilentTorrentArc1 = 49999, // 233C->self, 4.0s cast, range ?-19 donut
     SilentTorrentArc2 = 50000, // 233C->self, 4.0s cast, range ?-19 donut
     SilentTorrentArc3 = 49998, // 233C->self, 4.0s cast, range ?-19 donut

--- a/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8EnuoEnums.cs
+++ b/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8EnuoEnums.cs
@@ -55,8 +55,8 @@ public enum AID : uint
     VacuumExplode = 50001, // 4DC4->self, 1.5s cast, range 7 circle
     DenseEmptiness = 50033, // 4DC1->self, 4.0+1.0s cast, single-target
     DenseEmptiness1 = 50035, // 233C->self, no cast, range 60 ?-degree cone
-    DeepFreeze = 50043, // 4DC1->self, 5.0+1.0s cast, range 40 circle
-    DeepFreeze1 = 50044, // 233C->players, 6.0s cast, range 40 circle
+    DeepFreezeCastBar = 50043, // 4DC1->self, 5.0+1.0s cast, range 40 circle
+    DeepFreeze = 50044, // 233C->players, 6.0s cast, range 40 circle
     AllForNaught = 50010, // 4DC1->self, 5.0s cast, single-target
     LoomingEmptiness = 50011, // 4DC7->self, 5.0s cast, single-target
     LoomingEmptiness1 = 49982, // 233C->self, 6.0s cast, range 100 circle

--- a/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8EnuoStates.cs
+++ b/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8EnuoStates.cs
@@ -61,12 +61,17 @@ sealed class Ex8EnuoStates : StateMachineBuilder
     private void GazeOfTheVoid(uint id, float delay)
     {
         Cast(id, (uint)AID.GazeOfTheVoid, delay, 6f, "Gaze of the Void")
-            .ActivateOnEnter<GazeOfTheVoidAOE>();
+            .ActivateOnEnter<GazeOfTheVoidAOE>()
+            .ActivateOnEnter<GazeOfTheVoidSoaks>();
     }
 
     private void Vacuum(uint id, float delay)
     {
-        Cast(id, (uint)AID.Vacuum, delay, 2.0f, "Vacuum");
+        Cast(id, (uint)AID.Vacuum, delay, 2.0f, "Vacuum")
+            .ActivateOnEnter<VacuumAOE>()
+            .ActivateOnEnter<VacuumArc1>()
+            .ActivateOnEnter<VacuumArc2>()
+            .ActivateOnEnter<VacuumArc3>();
     }
 
     private void DeepFreeze(uint id, float delay)

--- a/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8EnuoStates.cs
+++ b/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8EnuoStates.cs
@@ -71,7 +71,8 @@ sealed class Ex8EnuoStates : StateMachineBuilder
             .ActivateOnEnter<VacuumAOE>()
             .ActivateOnEnter<VacuumArc1>()
             .ActivateOnEnter<VacuumArc2>()
-            .ActivateOnEnter<VacuumArc3>();
+            .ActivateOnEnter<VacuumArc3>()
+            .ActivateOnEnter<VacuumTelegraph>();
     }
 
     private void DeepFreeze(uint id, float delay)

--- a/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8EnuoStates.cs
+++ b/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8EnuoStates.cs
@@ -77,7 +77,9 @@ sealed class Ex8EnuoStates : StateMachineBuilder
 
     private void DeepFreeze(uint id, float delay)
     {
-        Cast(id, (uint)AID.DeepFreeze, delay, 5f, "Deep Freeze");
+        Cast(id, (uint)AID.DeepFreezeCastBar, delay, 5f, "Deep Freeze")
+            .ActivateOnEnter<DeepFreezeFlares>()
+            .ActivateOnEnter<DeepFreeze>();
     }
 
     //private void XXX(uint id, float delay)

--- a/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/GazeOfTheVoid.cs
+++ b/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/GazeOfTheVoid.cs
@@ -1,0 +1,94 @@
+﻿using BossMod.Shadowbringers.Dungeon.D05MtGulg.D055ForgivenObscenity;
+
+namespace BossMod.Modules.Dawntrail.Extreme.Ex8Enuo;
+
+sealed class GazeOfTheVoidAOE(BossModule module) : Components.SimpleAOEs(module, (uint)AID.GazeOfTheVoid2, new AOEShapeCone(40f, 22.5f.Degrees()), 7); // This is the easy part!
+
+sealed class GazeOfTheVoidSoaks(BossModule module) : BossComponent(module)
+{
+    //TODO: We could probably filter these by distance to the boss?
+    public static List<Actor> GetSmallOrbs(BossModule module)
+    {
+        var orbs = module.Enemies((uint)OID.VoidSoakSmall);
+        var count = orbs.Count;
+        return count == 0 ? [] : orbs;
+    }
+    public static List<Actor> GetBigOrbs(BossModule module)
+    {
+        var orbs = module.Enemies((uint)OID.VoidSoakLarge);
+        var count = orbs.Count;
+        return count == 0 ? [] : orbs;
+    }
+    public override void AddGlobalHints(GlobalHints hints)
+    {
+        if (GetSmallOrbs(Module).Count != 0 || GetBigOrbs(Module).Count != 0)
+            hints.Add("Soak the orbs in pairs!");
+    }
+
+    //TODO: These AI hints are pretty basic -- They'll point us in the correct direction but we're not waiting for pairs or prioritizing the closest to the boss.
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        var orbs = GetSmallOrbs(Module);
+        var count = orbs.Count;
+        var bigorbs = GetBigOrbs(Module);
+        var bigcount = bigorbs.Count;
+        if (actor.Role != Role.Tank)
+        {
+            if (count != 0)
+            {
+                var orbz = new ShapeDistance[count];
+                hints.ActionsToExecute.Push(ActionDefinitions.IDSprint, actor, ActionQueue.Priority.High);
+                for (var i = 0; i < count; ++i)
+                {
+                    var o = orbs[i];
+                    orbz[i] = new SDInvertedRect(o.Position + 0.5f * o.Rotation.ToDirection(), new WDir(default, 1f), 0.5f, 0.5f, 0.5f);
+                }
+                hints.AddForbiddenZone(new SDIntersection(orbz), DateTime.MaxValue);
+            }
+        }
+        if (actor.Role == Role.Tank)
+        {
+            if (bigcount != 0)
+            {
+                var orbz = new ShapeDistance[bigcount];
+                hints.ActionsToExecute.Push(ActionDefinitions.IDSprint, actor, ActionQueue.Priority.High);
+                for (var i = 0; i < bigcount; ++i)
+                {
+                    var o = bigorbs[i];
+                    orbz[i] = new SDInvertedRect(o.Position + 0.5f * o.Rotation.ToDirection(), new WDir(default, 1f), 0.5f, 0.5f, 0.5f);
+                }
+                hints.AddForbiddenZone(new SDIntersection(orbz), DateTime.MaxValue);
+            }
+        }
+    }
+    public override void DrawArenaForeground(int pcSlot, Actor pc)
+    {
+        var orbs = GetSmallOrbs(Module);
+        var count = orbs.Count;
+        var bigorbs = GetBigOrbs(Module);
+        var bigcount = bigorbs.Count;
+        if (pc.Role != Role.Tank)
+        {
+
+            for (var i = 0; i < count; ++i)
+            {
+                Arena.AddCircle(orbs[i].Position, 1f, Colors.Safe);
+            }
+            for (var i = 0; i < bigcount; ++i)
+            {
+                Arena.AddCircle(bigorbs[i].Position, 1f, Colors.Danger);
+            }
+        }
+        if (pc.Role == Role.Tank)
+        {
+            for (var i = 0; i < bigcount; ++i)
+            {
+                Arena.AddCircle(bigorbs[i].Position, 1f, Colors.Safe);
+            }
+            for (var i = 0; i < count; ++i)
+            {
+                Arena.AddCircle(orbs[i].Position, 1f, Colors.Danger);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Snuck in DeepFreeze - That completes P1!

Gaze and Vacuum are both fairly basic implementations, but they'll do for now -- Vacuum now has a better telegraph of the secondary explosions, though they vanish briefly as the cast ends and the actors move.

Gaze just shows the orbs and which ones you should hit based on if you're a tank -- no attempt at ordering yet or at convincing AI it needs to stack.