### PR TITLE
Add movement safety IPC and minor fixes for modules

### DIFF
--- a/BossMod/Framework/IPCProvider.cs
+++ b/BossMod/Framework/IPCProvider.cs
@@ -141,18 +141,18 @@ sealed class IPCProvider : IDisposable
         Register("Hints.ForceCancelCast", () => hints.ForceCancelCast);
         Register("Hints.ForbiddenZonesCount", () => hints.ForbiddenZones.Count);
         Register("Hints.ForbiddenZonesNextActivation", () => hints.ForbiddenZones.Count == 0 ? float.MaxValue : (float)(hints.ForbiddenZones[0].activation - DateTime.Now).TotalSeconds);
-        Register("Hints.ArenaCenter", () => new System.Numerics.Vector2(hints.PathfindMapCenter.X, hints.PathfindMapCenter.Z));
+        Register("Hints.ArenaCenter", () => new Vector2(hints.PathfindMapCenter.X, hints.PathfindMapCenter.Z));
         Register("Hints.ArenaRadius", () => hints.PathfindMapBounds.Radius);
         Register("Hints.PredictedDamagePlayers", () => hints.PredictedDamage.Count == 0 ? 0ul : hints.PredictedDamage[0].Players.Raw);
         Register("Hints.ForbiddenDirectionsCount", () => hints.ForbiddenDirections.Count);
         Register("Hints.ShouldCleansePlayers", () => hints.ShouldCleanse.Raw);
         Register("Hints.InteractWithTargetOID", () => hints.InteractWithTarget?.InstanceID ?? 0ul);
         Register("Hints.RecommendedPositional", () => (int)hints.RecommendedPositional.Pos);
-        Register("AI.PauseMovement", (bool pause) => Service.Config.Get<AI.AIConfig>().ForbidMovement = pause);
+        Register("AI.PauseMovement", (bool pause) => Service.Config.Get<AIConfig>().ForbidMovement = pause);
         Register("AI.NaviTargetPos", () =>
         {
             var pos = ai.Controller.NaviTargetPos;
-            return pos.HasValue ? new System.Numerics.Vector3(pos.Value.X, 0, pos.Value.Z) : (System.Numerics.Vector3?)null;
+            return pos.HasValue ? new Vector3(pos.Value.X, 0, pos.Value.Z) : (Vector3?)null;
         });
         Register("AI.IsNavigating", () => ai.Controller.NaviTargetPos != null);
         Register("AI.PlayerSpeed", () => ai.WorldState.Client.MoveSpeed);
@@ -194,6 +194,43 @@ sealed class IPCProvider : IDisposable
         {
             return hints.ImminentSpecialMode == default ? 0 : (int)hints.ImminentSpecialMode.mode;
         });
+
+        // Returns true if the destination position is safe (within arena bounds, not in a forbidden zone or temporary obstacle).
+        // 'from' is the player's current world position (XZ used); 'to' is the intended destination (XZ used).
+        // Use this to validate movement-ability targets before executing them.
+        Register("Hints.IsPositionSafe", (Vector3 to) =>
+        {
+            var player = bossmod.WorldState.Party.Player();
+            return player != null && !ActionDefinitions.IsDashDangerous(player.Position, new WPos(to.X, to.Z), hints);
+        });
+
+        // Same as Hints.IsPositionSafe but with an explicit source position, useful when the dash origin differs from the player's current position.
+        Register("Hints.IsDashSafe", (Vector3 from, Vector3 to) =>
+            !ActionDefinitions.IsDashDangerous(new WPos(from.X, from.Z), new WPos(to.X, to.Z), hints));
+
+        // Returns true if dashing forward (or backward) by 'range' yalms from the player's current position/rotation is safe.
+        // Mirrors DashFixedDistanceCheck: dest = playerPos + playerRotation * range (negated when backwards=true).
+        Register("Hints.IsFixedDashSafe", (float range, bool backwards) =>
+        {
+            var player = bossmod.WorldState.Party.Player();
+            if (player == null)
+                return false;
+            var dest = player.Position + player.Rotation.ToDirection() * range * (backwards ? -1f : 1f);
+            return !ActionDefinitions.IsDashDangerous(player.Position, dest, hints);
+        });
+
+        // Returns true if backdashing 'range' yalms directly away from 'enemyPos' is safe.
+        // Mirrors BackdashCheck: dir = normalize(playerPos - enemyPos), dest = playerPos + dir * range.
+        Register("Hints.IsBackdashSafe", (Vector3 enemyPos, float range) =>
+        {
+            var player = bossmod.WorldState.Party.Player();
+            if (player == null)
+                return false;
+            var dir = (player.Position - new WPos(enemyPos.X, enemyPos.Z)).Normalized();
+            var dest = player.Position + dir * range;
+            return !ActionDefinitions.IsDashDangerous(player.Position, dest, hints);
+        });
+
         Register("Configuration", (List<string> args, bool save) => Service.Config.ConsoleCommand(args.AsSpan(), save));
 
         var lastModified = DateTime.Now;

--- a/BossMod/Modules/Dawntrail/Raid/M07NBruteAbombinator/M07NBruteAbombinator.cs
+++ b/BossMod/Modules/Dawntrail/Raid/M07NBruteAbombinator/M07NBruteAbombinator.cs
@@ -56,6 +56,8 @@ sealed class NeoBombarianSpecialKB(BossModule module) : Components.SimpleKnockba
                 poly = KnockbackArena.Polygon.Offset(-1f); // shrink polygon by 1 yalm for less suspect kb
                 polyInit = true;
             }
+            if (Casters.Count == 0)
+                return;
             ref var c = ref Casters.Ref(0);
             hints.AddForbiddenZone(new SDKnockbackInComplexPolygonAwayFromOrigin(Arena.Center, Module.PrimaryActor.Position, 58f, poly), c.Activation);
         }

--- a/BossMod/Modules/Dawntrail/Trial/T08Enuo/T08Enuo.cs
+++ b/BossMod/Modules/Dawntrail/Trial/T08Enuo/T08Enuo.cs
@@ -1,6 +1,5 @@
 namespace BossMod.Dawntrail.Trial.T08Enuo;
 
-
 public enum OID : uint
 {
     Enuo = 0x4DB9,
@@ -17,7 +16,7 @@ public enum OID : uint
     Golbez = 0x4DC0,
 }
 
-public enum AID: uint
+public enum AID : uint
 {
     _AutoAttack_ = 49936, // Enuo->player, no cast, single-target
     Meteorain = 49971, // Enuo->self, no cast, range 40 circle
@@ -112,7 +111,6 @@ public enum TetherID : uint
     _Gen_Tether_chn_z5fd08_0a1 = 392, // _Gen_->Enuo
 }
 
-
 class Meteorain(BossModule module) : Components.RaidwideCast(module, (uint)AID.Meteorain);
 
 sealed class NaughtGrowsAOE(BossModule module) : Components.SimpleAOEs(module, (uint)AID.NaughtGrowsAOE, new AOEShapeCircle(40f));
@@ -121,14 +119,13 @@ sealed class NaughtGrowsAOE(BossModule module) : Components.SimpleAOEs(module, (
 sealed class GazeOfTheVoidCones(BossModule module) : Components.SimpleAOEGroups(module, [(uint)AID.GazeOfTheVoidCones, (uint)AID.GazeOfTheVoid1], new AOEShapeCone(20f, 22.5f.Degrees()), 7, 10);
 
 // Flare marker : tank buster magic damage
-sealed class DeepFreeze(BossModule module) : Components.BaitAwayCast(module, (uint)AID.DeepFreeze,new AOEShapeCircle(8), true, true);
+sealed class DeepFreeze(BossModule module) : Components.BaitAwayCast(module, (uint)AID.DeepFreeze, new AOEShapeCircle(8), true, true);
 
 //Naughthunts
 //TODO: Should update Chaser.target on Haunts Another
 // They will need to be getting line drawn to them and old targets not highlighted.
 // For now only does the first 12 chase AOE.
 sealed class EndlessChase(BossModule module) : Components.StandardChasingAOEs(module, 7f, (uint)AID.EndlessChaseFirst, (uint)AID.EndlessChaseRest, 2.9f, 1.5d, 12, true, (uint)IconID.EndlessChaseIcon);
-
 
 //enshrouded holy - stack marker
 sealed class ShroudedHoly(BossModule module) : Components.StackWithCastTargets(module, (uint)AID.ShroudedHolyStack, 7, 4);
@@ -156,7 +153,7 @@ class ArenaSwitcher : BossComponent
     public override void OnActorCreated(Actor actor)
     {
         if ((OID)actor.OID == OID.BeaconInTheDark)
-           Beacon = actor;
+            Beacon = actor;
     }
 
     public override void OnMapEffect(byte index, uint state)
@@ -176,12 +173,11 @@ class LoomingShadow(BossModule module) : Components.Adds(module, (uint)OID.Loomi
 class Shadows(BossModule module) : Components.Adds(module, (uint)OID.UncastShadow, 1);
 class Beacon(BossModule module) : Components.Adds(module, (uint)OID.BeaconInTheDark, 1, true);
 
-
 class EmptyShadow(BossModule module) : Components.SimpleAOEs(module, (uint)AID.EmptyShadowAOE, new AOEShapeCircle(10f));
 // big explosion For when Looming emptiness spawns. Went a little small: proximity AOE
 class LoomingEmptinessAOE(BossModule module) : Components.SimpleAOEs(module, (uint)AID.LoomingEmptinessAOE, 42f);
 
-class Nothingness(BossModule module) : Components.SimpleAOEs(module, (uint)AID.Nothingness, new AOEShapeRect(100f,2f));
+class Nothingness(BossModule module) : Components.SimpleAOEs(module, (uint)AID.Nothingness, new AOEShapeRect(100f, 2f));
 
 // back to circle arena
 
@@ -197,7 +193,6 @@ class Almagest(BossModule module) : Components.RaidwideCast(module, (uint)AID.Al
 sealed class NaughtGrows(BossModule module) : Components.SimpleAOEs(module, (uint)AID.NaughtGrowsAOESmall, 12f);
 
 sealed class DimensionZero(BossModule module) : Components.LineStack(module, iconID: (uint)IconID.DimensionZeroIcon, (uint)AID.DimensionZeroRect, 0d, 60f, 4f, 8);
-
 
 [SkipLocalsInit]
 sealed class EnuoStates : StateMachineBuilder
@@ -241,21 +236,21 @@ sealed class EnuoStates : StateMachineBuilder
 }
 
 [ModuleInfo(BossModuleInfo.Maturity.WIP,
-    StatesType = typeof(EnuoStates),
-    ConfigType = null, // replace null with typeof(EnuoConfig) if applicable
-    ObjectIDType = typeof(OID),
-    ActionIDType = typeof(AID),
-    StatusIDType = null, // replace null with typeof(SID) if applicable
-    TetherIDType = typeof(TetherID),
-    IconIDType = typeof(IconID),
-    PrimaryActorOID = (uint)OID.Enuo,
-    Contributors = "Wen",
-    Expansion = BossModuleInfo.Expansion.Dawntrail,
-    Category = BossModuleInfo.Category.Trial,
-    GroupType = BossModuleInfo.GroupType.CFC,
-    GroupID = 1115u,
-    NameID = 14749u,
-    SortOrder = 1,
-    PlanLevel = 0)]
+StatesType = typeof(EnuoStates),
+ConfigType = null, // replace null with typeof(EnuoConfig) if applicable
+ObjectIDType = typeof(OID),
+ActionIDType = typeof(AID),
+StatusIDType = null, // replace null with typeof(SID) if applicable
+TetherIDType = typeof(TetherID),
+IconIDType = typeof(IconID),
+PrimaryActorOID = (uint)OID.Enuo,
+Contributors = "Wen",
+Expansion = BossModuleInfo.Expansion.Dawntrail,
+Category = BossModuleInfo.Category.Trial,
+GroupType = BossModuleInfo.GroupType.CFC,
+GroupID = 1115u,
+NameID = 14749u,
+SortOrder = 1,
+PlanLevel = 0)]
 [SkipLocalsInit]
 public sealed class Enuo(WorldState ws, Actor primary) : BossModule(ws, primary, new(100f, 100f), new ArenaBoundsCircle(20f));


### PR DESCRIPTION
Added new IPCProvider endpoints for movement safety checks (IsPositionSafe, IsDashSafe, IsFixedDashSafe, IsBackdashSafe). Simplified Vector2/Vector3 type usage, updated AI.PauseMovement registration, and improved null safety in NeoBombarianSpecialKB. Reformatted enums, component instantiations, and attributes in T08Enuo.cs for consistency and clarity.