### PR TITLE
Ex8 Tweaks and Bugfixes

### DIFF
--- a/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8Enuo.cs
+++ b/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8Enuo.cs
@@ -82,6 +82,7 @@ sealed class DimensionZero(BossModule module) : Components.GenericBaitStack(modu
             var p = WorldState.Actors.Find(targetID);
             if (p != null)
             {
+                hits = 0; //reset your counter, dummy.
                 CurrentBaits.Add(new(Module.PrimaryActor, p, new AOEShapeRect(60f, 4f)));
             }
         }
@@ -91,7 +92,7 @@ sealed class DimensionZero(BossModule module) : Components.GenericBaitStack(modu
         if (spell.Action.ID == (uint)AID.DimensionZeroHits)
         {
             hits++;
-            if (hits <= 3)
+            if (hits >= 3)
             {
                 CurrentBaits.Clear();
             }

--- a/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8EnuoEnums.cs
+++ b/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8EnuoEnums.cs
@@ -19,7 +19,7 @@ public enum OID : uint
     ProtectiveShadow = 0x4DC8, // R5.000, x0 (spawn during fight)
     LoomingShadow = 0x4DC7, // R12.500, x0 (spawn during fight)
     BeaconInTheDark = 0x4DCB, // R5.000, x0 (spawn during fight)
-    Void5 = 0x4EB5, // R0.850, x0 (spawn during fight), Helper type
+    NaughtHuntChaser = 0x4EB5, // R0.850, x0 (spawn during fight), Helper type
 
 }
 

--- a/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8EnuoStates.cs
+++ b/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/Ex8EnuoStates.cs
@@ -72,6 +72,9 @@ sealed class Ex8EnuoStates : StateMachineBuilder
         Emptiness(id + 0x13, 23.27f);
         NaughtHunts(id + 0x14, 6.26f);
         Emptiness(id + 0x15, 23.24f);
+        DimensionZero(id + 0x17, 5.2f);
+        Almagest(id + 0x17, 10.1f);
+        DoubleNaughtGrows(id + 0x18, 5.7f);
 
     }
 

--- a/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/NaughtHunts.cs
+++ b/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/NaughtHunts.cs
@@ -2,19 +2,38 @@
 
 // May want some additional signaling to the secondary target?  But this seems to work.
 
-sealed class NaughtHunts(BossModule module) : Components.StandardChasingAOEs(module, new AOEShapeCircle(6f), (uint)AID.EndlessChaseCast, (uint)AID.EndlessChaseInstant, 2.9f, 0.7d, 12, icon: (uint)IconID.NaughtHuntTarget, activationDelay: 6d)
+sealed class NaughtHunts(BossModule module) : Components.StandardChasingAOEs(module, new AOEShapeCircle(6f), (uint)AID.EndlessChaseCast, (uint)AID.EndlessChaseInstant, 2.9f, 0.7d, 13, icon: (uint)IconID.NaughtHuntTarget, activationDelay: 6d)
 {
+    private int _tethercount = 0;
     public override void OnTethered(Actor source, in ActorTetherInfo tether)
     {
         if (tether.ID == (uint)TetherID.NaughtHuntFirst)
         {
             var p = WorldState.Actors.Find(tether.Target);
+            if (_tethercount == 2)
+            {
+                Chasers.Clear();
+            }
             if (p != null)
             {
                 Chasers.Add(new(Shape, p, source.Position, 0, MaxCasts, WorldState.FutureTime(ActivationDelay), SecondsBetweenActivations));
+                ++_tethercount;
+            }
+            if (_tethercount == 4)
+            {
+                _tethercount = 0;
             }
         }
     }
+
+    public override void OnActorDestroyed(Actor actor)
+    {
+        if (actor.OID == (uint)OID.NaughtHuntChaser)
+        {
+            Chasers.Clear(); // This'll happen twice per cycle but who cares?
+        }
+    }
+
     public override void OnCastStarted(Actor caster, ActorCastInfo spell)
     {
         if (spell.Action.ID == ActionFirst)


### PR DESCRIPTION
Tweak for NaughtHunts to change the way we clear the chasers, using the retether and the death of the chasing actor as our cue instead of the apparently-variable cast number.

Dimension Zero had its' test reverse and wasn't resetting its' counter.

Timeline extended to the final Naught Grows.