### PR TITLE
Add null checks for group and player in party sync

### DIFF
--- a/BossMod/Framework/WorldStateGameSync.cs
+++ b/BossMod/Framework/WorldStateGameSync.cs
@@ -627,7 +627,7 @@ sealed class WorldStateGameSync : IDisposable
                     Service.Log($"[WSG] Object #0 is valid ({pc->AccountId:X}.{pc->ContentId:X}, {pc->EntityId:X8} '{pc->NameString}') while player is not logged in");
                 }
 
-                if (group->MemberCount > 0)
+                if (group != null && group->MemberCount > 0)
                 {
                     Service.Log($"[WGS] Group is non-empty while player is not logged in");
                 }
@@ -643,7 +643,7 @@ sealed class WorldStateGameSync : IDisposable
             // else: just assume there's no player for now...
         }
 
-        var member = player.InstanceId != default ? group->GetPartyMemberByEntityId((uint)player.InstanceId) : null;
+        var member = player.InstanceId != default && group != null ? group->GetPartyMemberByEntityId((uint)player.InstanceId) : null;
         if (member != null)
         {
             player.InCutscene |= (member->Flags & 0x10) != default;
@@ -655,6 +655,9 @@ sealed class WorldStateGameSync : IDisposable
 
     private unsafe void UpdatePartyNormal(GroupManager.Group* group, PartyMember* player)
     {
+        if (group == null)
+            return;
+
         // first iterate over previous members, search for match in game state, and reconcile differences - update or remove
         for (var i = PartyState.PlayerSlot + 1; i < PartyState.MaxPartySize; ++i)
         {
@@ -681,7 +684,11 @@ sealed class WorldStateGameSync : IDisposable
         for (var i = 0; i < group->MemberCount; ++i)
         {
             var member = group->PartyMembers.GetPointer(i);
-            if (member->ContentId != player->ContentId && Array.FindIndex(_ws.Party.Members, m => m.ContentId == member->ContentId) < 0)
+            if (player != null && member->ContentId != player->ContentId && Array.FindIndex(_ws.Party.Members, m => m.ContentId == member->ContentId) < 0)
+            {
+                AddPartyMember(BuildPartyMember(member));
+            }
+            else if (player == null && Array.FindIndex(_ws.Party.Members, m => m.ContentId == member->ContentId) < 0)
             {
                 AddPartyMember(BuildPartyMember(member));
             }
@@ -704,6 +711,9 @@ sealed class WorldStateGameSync : IDisposable
 
     private unsafe void UpdatePartyAlliance(GroupManager.Group* group)
     {
+        if (group == null)
+            return;
+
         // note: we don't support small-group alliance (should we?)
         // unlike normal party, game's alliance slots never change, so we just keep 1:1 mapping
         var isNormalAlliance = group->IsAlliance && !group->IsSmallGroupAlliance;


### PR DESCRIPTION
Improved robustness by adding null checks for the group pointer in multiple methods of WorldStateGameSync to prevent null reference exceptions. Also added a null check for the player pointer in UpdatePartyNormal when comparing content IDs. These changes help prevent crashes due to null pointers.