### PR TITLE
Fix NRE in T08ThornmarchH PomMeteor static initializer

### DIFF
--- a/BossMod/Modules/RealmReborn/Trial/T08ThornmarchH/PomMeteor.cs
+++ b/BossMod/Modules/RealmReborn/Trial/T08ThornmarchH/PomMeteor.cs
@@ -15,7 +15,7 @@ class PomMeteor(BossModule module) : BossComponent(module)
     {
         var towerOffsets = new WDir[8];
         for (var i = 0; i < 8; ++i)
-            _towerOffsets[i] = 10f * (45f * i).Degrees().ToDirection();
+            towerOffsets[i] = 10f * (45f * i).Degrees().ToDirection();
         return towerOffsets;
     }
 


### PR DESCRIPTION
## Summary
Fixes a `NullReferenceException` thrown from the static constructor of
`BossMod.RealmReborn.Trial.T08ThornmarchH.PomMeteor`, which surfaced as a `TypeInitializationException` and broke AI
hint calculation.

## Cause
Inside `GetTowerOffsets()`, the loop was assigning to the still-uninitialized static field `_towerOffsets` instead of
the local variable `towerOffsets` that is returned. Since the static field is being initialized *from* the return
value of this method, it is `null` while the method runs.

```csharp
private static readonly WDir[] _towerOffsets = GetTowerOffsets();
private static WDir[] GetTowerOffsets()
{
var towerOffsets = new WDir[8];
for (var i = 0; i < 8; ++i)
_towerOffsets[i] = 10f * (45f * i).Degrees().ToDirection(); // null deref
return towerOffsets;
}
```

**Fix**

Write to the local towerOffsets[i] instead, so the populated array is returned and assigned to _towerOffsets.

Stack trace (before fix)
```
System.TypeInitializationException: The type initializer for
'BossMod.RealmReborn.Trial.T08ThornmarchH.PomMeteor' threw an exception.
---> System.NullReferenceException: Object reference not set to an instance of an object.
at BossMod.RealmReborn.Trial.T08ThornmarchH.PomMeteor.GetTowerOffsets()
in PomMeteor.cs:line 18
at BossMod.RealmReborn.Trial.T08ThornmarchH.PomMeteor..cctor()
in PomMeteor.cs:line 13
```