### PR TITLE
Fixes for Idyllic Dream Towers phase and Party Role Assignment enhancements

### DIFF
--- a/BossMod/Config/PartyRolesConfig.cs
+++ b/BossMod/Config/PartyRolesConfig.cs
@@ -8,6 +8,9 @@ public class PartyRolesConfig : ConfigNode
 {
     public enum Assignment { MT, OT, H1, H2, M1, M2, R1, R2, Unassigned }
 
+    [PropertyDisplay("Automatically assign roles on zone change")]
+    public bool AutoAssignOnDutyEnter = false;
+
     public Dictionary<ulong, Assignment> Assignments = [];
 
     public Assignment this[ulong contentID] => Assignments.GetValueOrDefault(contentID, Assignment.Unassigned);
@@ -75,8 +78,146 @@ public class PartyRolesConfig : ConfigNode
         return res;
     }
 
+    // automatically assign party roles based on job priority and party composition
+    public void AutoAssignRoles(PartyState party)
+    {
+        // collect all valid party members with their jobs
+        List<(ulong contentId, Class job, Role role, ClassCategory category)> members = [];
+        for (var i = 0; i < PartyState.MaxPartySize; ++i)
+        {
+            ref var m = ref party.Members[i];
+            if (m.IsValid() && m.ContentId != 0)
+            {
+                var actor = party[i];
+                if (actor != null)
+                {
+                    members.Add((m.ContentId, actor.Class, actor.Role, actor.Class.GetClassCategory()));
+                }
+            }
+        }
+
+        // separate by role
+        List<(ulong contentId, Class job, Role role, ClassCategory category)> tanks = [];
+        List<(ulong contentId, Class job, Role role, ClassCategory category)> healers = [];
+        List<(ulong contentId, Class job, Role role, ClassCategory category)> melee = [];
+        List<(ulong contentId, Class job, Role role, ClassCategory category)> ranged = [];
+
+        foreach (var member in members)
+        {
+            if (member.role == Role.Tank)
+                tanks.Add(member);
+            else if (member.role == Role.Healer)
+                healers.Add(member);
+            else if (member.role == Role.Melee)
+                melee.Add(member);
+            else if (member.role == Role.Ranged)
+                ranged.Add(member);
+        }
+
+        // tank priority: PLD > WAR > DRK > GNB for MT, reverse for OT
+        tanks.Sort((a, b) => GetTankPriority(a.job).CompareTo(GetTankPriority(b.job)));
+        if (tanks.Count > 0)
+            Assignments[tanks[0].contentId] = Assignment.MT;
+        if (tanks.Count > 1)
+            Assignments[tanks[1].contentId] = Assignment.OT;
+
+        // healer priority: WHM > AST > SCH > SGE for H1, reverse for H2
+        healers.Sort((a, b) => GetHealerPriority(a.job).CompareTo(GetHealerPriority(b.job)));
+        if (healers.Count > 0)
+            Assignments[healers[0].contentId] = Assignment.H1;
+        if (healers.Count > 1)
+            Assignments[healers[1].contentId] = Assignment.H2;
+
+        // sort ranged by priority first
+        ranged.Sort((a, b) => GetRangedPriority(a.job).CompareTo(GetRangedPriority(b.job)));
+
+        // melee DPS - if 3+ ranged, fill melee slots from the lowest priority ranged
+        if (ranged.Count >= 3)
+        {
+            // first try to move RDM to melee (if it exists and is low priority)
+            var rdmIndex = -1;
+            for (var i = 0; i < ranged.Count; ++i)
+            {
+                if (ranged[i].job == Class.RDM)
+                {
+                    rdmIndex = i;
+                    break;
+                }
+            }
+
+            if (rdmIndex >= 0)
+            {
+                melee.Add(ranged[rdmIndex]);
+                ranged.RemoveAt(rdmIndex);
+            }
+        }
+
+        // if we still need more melee slots and have ranged to spare, move lowest priority ranged
+        while (melee.Count < 2 && ranged.Count > 2)
+        {
+            // take from the end (lowest priority)
+            var lastIndex = ranged.Count - 1;
+            melee.Add(ranged[lastIndex]);
+            ranged.RemoveAt(lastIndex);
+        }
+
+        // assign melee by party order
+        for (var i = 0; i < melee.Count && i < 2; ++i)
+        {
+            Assignments[melee[i].contentId] = i == 0 ? Assignment.M1 : Assignment.M2;
+        }
+
+        // assign ranged (already sorted by priority)
+        if (ranged.Count > 0)
+            Assignments[ranged[0].contentId] = Assignment.R1;
+        if (ranged.Count > 1)
+            Assignments[ranged[1].contentId] = Assignment.R2;
+
+        Modified.Fire();
+    }
+
+    private static int GetTankPriority(Class job) => job switch
+    {
+        Class.PLD or Class.GLA => 1,
+        Class.WAR or Class.MRD => 2,
+        Class.DRK => 3,
+        Class.GNB => 4,
+        _ => 99
+    };
+
+    private static int GetHealerPriority(Class job) => job switch
+    {
+        Class.WHM or Class.CNJ => 1,
+        Class.AST => 2,
+        Class.SCH => 3,
+        Class.SGE => 4,
+        _ => 99
+    };
+
+    private static int GetRangedPriority(Class job) => job switch
+    {
+        // R1 priority: MCH > BRD > DNC > casters
+        Class.MCH => 1,
+        Class.BRD or Class.ARC => 2,
+        Class.DNC => 3,
+        // casters
+        Class.BLM or Class.THM => 4,
+        Class.SMN or Class.ACN => 5,
+        Class.RDM => 6,
+        Class.PCT => 7,
+        Class.BLU => 8,
+        _ => 99
+    };
+
     public override void DrawCustom(UITree tree, WorldState ws)
     {
+        if (ImGui.Button("Auto-Assign Roles"))
+        {
+            AutoAssignRoles(ws.Party);
+        }
+        ImGui.SameLine();
+        ImGui.TextUnformatted("Click to automatically assign party roles based on job and party order");
+
         using (var table = ImRaii.Table("tab2", 10, ImGuiTableFlags.SizingFixedFit))
         {
             if (table)

--- a/BossMod/Framework/Plugin.cs
+++ b/BossMod/Framework/Plugin.cs
@@ -35,6 +35,7 @@ public sealed class Plugin : IAsyncDalamudPlugin
     private IPCProvider _ipc = null!;
     private DTRProvider _dtr = null!;
     private MultiboxManager _mbox = null!;
+    private PartyRolesManager _partyRoles = null!;
     private TimeSpan _prevUpdateTime;
     private DateTime _throttleJump;
     private DateTime _throttleInteract;
@@ -121,6 +122,7 @@ public sealed class Plugin : IAsyncDalamudPlugin
         _ipc = new(_bossmod, _hints, _rotation, _amex, _movementOverride, _ai, _hintsBuilder.Obstacles);
         _dtr = new(_rotation, _ai);
         _mbox = new(_rotation, _ws);
+        _partyRoles = new(_ws);
         _wndBossmod = new(_bossmod, _zonemod);
         _wndBossmodHints = new(_bossmod, _zonemod);
         _wndZone = new(_zonemod);
@@ -153,6 +155,7 @@ public sealed class Plugin : IAsyncDalamudPlugin
         _wndBossmodHints.Dispose();
         _wndBossmod.Dispose();
         _configUI.Dispose();
+        _partyRoles.Dispose();
         _mbox.Dispose();
         _dtr.Dispose();
         _ipc.Dispose();
@@ -290,6 +293,7 @@ public sealed class Plugin : IAsyncDalamudPlugin
         _dtr.Update();
         Camera.Instance?.Update();
         _wsSync.Update(_prevUpdateTime);
+        _partyRoles.Update();
         _bossmod.Update();
         _zonemod.ActiveModule?.Update();
         _hintsBuilder.Update(_hints, PartyState.PlayerSlot, moveImminent);

--- a/BossMod/Framework/Service.cs
+++ b/BossMod/Framework/Service.cs
@@ -45,7 +45,7 @@ public sealed class Service
 
     public static WindowSystem? WindowSystem;
 
-    public static ImFontPtr IconFont => Dalamud.Interface.UiBuilder.IconFont;
+    public static ImFontPtr IconFont => UiBuilder.IconFont;
 #pragma warning restore CA2211
 
     public static readonly ConfigRoot Config = new();

--- a/BossMod/Modules/Dawntrail/Savage/M12SP2Lindwurm/IdyllicDreamTowers.cs
+++ b/BossMod/Modules/Dawntrail/Savage/M12SP2Lindwurm/IdyllicDreamTowers.cs
@@ -107,6 +107,46 @@ sealed class IdyllicDreamArena(BossModule module) : Components.GenericAOEs(modul
     }
 }
 
+// Shared state for Idyllic Dream to persist tower assignments across component lifecycles
+class IdyllicDreamSharedState : BossComponent
+{
+    public readonly int[] TowerAssignments = new int[PartyState.MaxPartySize];
+    public readonly Element[] TowerElements = new Element[PartyState.MaxPartySize];
+    public readonly WPos[] TowerPositions = new WPos[8]; // Store positions of all 8 towers
+
+    public IdyllicDreamSharedState(BossModule module) : base(module)
+    {
+        Array.Fill(TowerAssignments, -1);
+    }
+
+    public void RecordTowerSoak(int slot, int towerIndex, Element element, WPos position)
+    {
+        if (slot >= 0 && slot < TowerAssignments.Length)
+        {
+            TowerAssignments[slot] = towerIndex;
+            TowerElements[slot] = element;
+        }
+        if (towerIndex >= 0 && towerIndex < TowerPositions.Length)
+        {
+            TowerPositions[towerIndex] = position;
+        }
+    }
+
+    public (int towerIndex, Element element, WPos position) GetTowerSoak(int slot)
+    {
+        if (slot >= 0 && slot < TowerAssignments.Length)
+        {
+            var towerIndex = TowerAssignments[slot];
+            var element = TowerElements[slot];
+            var position = towerIndex >= 0 && towerIndex < TowerPositions.Length
+                ? TowerPositions[towerIndex]
+                : default;
+            return (towerIndex, element, position);
+        }
+        return (-1, Element.None, default);
+    }
+}
+
 class ArcadianArcanum(BossModule module) : Components.UniformStackSpread(module, 0, 6)
 {
     public int NumCasts;
@@ -140,6 +180,10 @@ sealed class IdyllicDreamElementalMeteor(BossModule module) : Components.Generic
 
     BitMask _lightVuln;
     public bool DrawIcons;
+
+    private readonly int[] _assignedTowers = Utils.MakeArray(PartyState.MaxPartySize, -1);
+
+    private readonly Tower[] _modifiedTowers = new Tower[8];
 
     public const uint ColorWind = 0xFF9ABB81;
     public const uint ColorDark = 0xFFE67AD2;
@@ -178,6 +222,30 @@ sealed class IdyllicDreamElementalMeteor(BossModule module) : Components.Generic
         }
     }
 
+    public override void Update()
+    {
+        if (DrawIcons && Towers.Count > 0)
+        {
+            var sharedState = Module.FindComponent<IdyllicDreamSharedState>();
+            if (sharedState != null)
+            {
+                foreach (var (slot, actor) in Raid.WithSlot(true))
+                {
+                    var assignedTower = _assignedTowers[slot];
+                    if (assignedTower >= 0 && assignedTower < Towers.Count && assignedTower < Meteors.Count)
+                    {
+                        var tower = Towers[assignedTower];
+                        if (tower.IsInside(actor))
+                        {
+                            var meteor = Meteors[assignedTower];
+                            sharedState.RecordTowerSoak(slot, assignedTower, meteor.Element, meteor.Position);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     public override void OnEventCast(Actor caster, ActorCastEvent spell)
     {
         if ((AID)spell.Action.ID != AID.CosmicKiss)
@@ -188,6 +256,7 @@ sealed class IdyllicDreamElementalMeteor(BossModule module) : Components.Generic
         Meteors.Clear();
         _lightVuln = default;
         DrawIcons = false;
+        Array.Fill(_assignedTowers, -1);
     }
 
     // --------------------------------------------------------
@@ -211,6 +280,514 @@ sealed class IdyllicDreamElementalMeteor(BossModule module) : Components.Generic
 
             Towers.Add(new(m.Position, 3, forbiddenSoakers: forbidden, activation: activation));
         }
+
+        AssignTowers();
+    }
+
+    private void AssignTowers()
+    {
+        var roleAssignments = Service.Config.Get<PartyRolesConfig>().SlotsPerAssignment(Raid);
+        if (roleAssignments.Length == 0)
+        {
+            Module.ReportError(this, "Tower assignments require party roles to be configured");
+            return;
+        }
+
+        var config = Service.Config.Get<M12S2LindwurmConfig>();
+
+        var mtSlot = roleAssignments[(int)PartyRolesConfig.Assignment.MT];
+        var otSlot = roleAssignments[(int)PartyRolesConfig.Assignment.OT];
+        var h1Slot = roleAssignments[(int)PartyRolesConfig.Assignment.H1];
+        var h2Slot = roleAssignments[(int)PartyRolesConfig.Assignment.H2];
+        var m1Slot = roleAssignments[(int)PartyRolesConfig.Assignment.M1];
+        var m2Slot = roleAssignments[(int)PartyRolesConfig.Assignment.M2];
+        var r1Slot = roleAssignments[(int)PartyRolesConfig.Assignment.R1];
+        var r2Slot = roleAssignments[(int)PartyRolesConfig.Assignment.R2];
+
+        var actualWestSlots = new List<int>();
+        var actualEastSlots = new List<int>();
+
+        if (config.IdyllicDreamAdjustToMistakes)
+        {
+            var slots = new[] { mtSlot, otSlot, h1Slot, h2Slot, m1Slot, m2Slot, r1Slot, r2Slot };
+            for (var i = 0; i < slots.Length; ++i)
+            {
+                var slot = slots[i];
+                if (slot < 0)
+                    continue;
+
+                var player = Raid[slot];
+                if (player == null)
+                    continue;
+
+                var pos = player.Position;
+                if (pos.InCircle(new WPos(86, 100), 10))
+                    actualWestSlots.Add(slot);
+                else if (pos.InCircle(new WPos(114, 100), 10))
+                    actualEastSlots.Add(slot);
+            }
+
+            // Only adjust if we have exactly 4 players on each platform
+            if (actualWestSlots.Count == 4 && actualEastSlots.Count == 4)
+            {
+                AssignTowersByActualPositions(actualWestSlots, actualEastSlots,
+                    mtSlot, h1Slot, m1Slot, r1Slot,
+                    otSlot, h2Slot, m2Slot, r2Slot);
+                return;
+            }
+        }
+
+        // Standard assignment: West = MT/H1/M1/R1, East = OT/H2/M2/R2
+        // Categorize meteors by position
+        // West/Left platform: x < 100 (centered at 86, 100)
+        // East/Right platform: x > 100 (centered at 114, 100)
+        var westTowers = new List<(int index, Meteor meteor, bool isNorth)>();
+        var eastTowers = new List<(int index, Meteor meteor, bool isNorth)>();
+
+        var meteors = CollectionsMarshal.AsSpan(Meteors);
+        for (var i = 0; i < meteors.Length; ++i)
+        {
+            ref var m = ref meteors[i];
+            var isWest = m.Position.X < 100;
+            var isNorth = m.Position.Z < 100;
+
+            if (isWest)
+                westTowers.Add((i, m, isNorth));
+            else
+                eastTowers.Add((i, m, isNorth));
+        }
+
+        // Sort towers: closer to boss (closer to center X) first, then by element type
+        westTowers.Sort((a, b) =>
+        {
+            var distA = Math.Abs(a.meteor.Position.X - 100);
+            var distB = Math.Abs(b.meteor.Position.X - 100);
+            return distA.CompareTo(distB);
+        });
+
+        eastTowers.Sort((a, b) =>
+        {
+            var distA = Math.Abs(a.meteor.Position.X - 100);
+            var distB = Math.Abs(b.meteor.Position.X - 100);
+            return distA.CompareTo(distB);
+        });
+
+        if (westTowers.Count != 4 || eastTowers.Count != 4)
+        {
+            Module.ReportError(this, $"Unexpected tower distribution: West={westTowers.Count}, East={eastTowers.Count}");
+            return;
+        }
+
+        // West platform (Light Party 2): MT, H1, M1, R1
+        // Initial assignment: MT & H1 (supports) take north towers, M1 & R1 take south towers
+        // Closer towers: MT & M1, Farther towers: H1 & R1
+        AssignPlatformTowers(westTowers,
+            mtSlot, h1Slot, m1Slot, r1Slot,
+            true); // West platform: supports north
+
+        // East platform (Light Party 1): OT, H2, M2, R2
+        // Initial assignment: M2 & R2 take north towers, OT & H2 take south towers
+        // Closer towers: OT & M2, Farther towers: H2 & R2
+        AssignPlatformTowers(eastTowers,
+            otSlot, h2Slot, m2Slot, r2Slot,
+            false); // East platform: DPS north
+    }
+
+    private void AssignTowersByActualPositions(
+        List<int> westSlots, List<int> eastSlots,
+        int mtSlot, int h1Slot, int m1Slot, int r1Slot,
+        int otSlot, int h2Slot, int m2Slot, int r2Slot)
+    {
+        var westRoles = DetermineRoleComposition(westSlots, mtSlot, h1Slot, m1Slot, r1Slot, otSlot, h2Slot, m2Slot, r2Slot);
+        var eastRoles = DetermineRoleComposition(eastSlots, mtSlot, h1Slot, m1Slot, r1Slot, otSlot, h2Slot, m2Slot, r2Slot);
+
+        // Validate role composition: must have exactly 2 supports and 2 DPS per platform
+        if (!westRoles.Valid || !eastRoles.Valid)
+        {
+            // Invalid composition detected - mechanic will fail regardless, don't adjust logic
+            Module.ReportError(this, "Invalid platform composition: mechanic requires 2 supports (tank/healer) and 2 DPS (melee/ranged) per platform");
+            return;
+        }
+
+        // Categorize meteors by position
+        var westTowers = new List<(int index, Meteor meteor, bool isNorth)>();
+        var eastTowers = new List<(int index, Meteor meteor, bool isNorth)>();
+
+        var meteors = CollectionsMarshal.AsSpan(Meteors);
+        for (var i = 0; i < meteors.Length; ++i)
+        {
+            ref var m = ref meteors[i];
+            var isWest = m.Position.X < 100;
+            var isNorth = m.Position.Z < 100;
+
+            if (isWest)
+                westTowers.Add((i, m, isNorth));
+            else
+                eastTowers.Add((i, m, isNorth));
+        }
+
+        // Sort towers by distance to center
+        westTowers.Sort((a, b) =>
+        {
+            var distA = Math.Abs(a.meteor.Position.X - 100);
+            var distB = Math.Abs(b.meteor.Position.X - 100);
+            return distA.CompareTo(distB);
+        });
+
+        eastTowers.Sort((a, b) =>
+        {
+            var distA = Math.Abs(a.meteor.Position.X - 100);
+            var distB = Math.Abs(b.meteor.Position.X - 100);
+            return distA.CompareTo(distB);
+        });
+
+        if (westTowers.Count != 4 || eastTowers.Count != 4)
+        {
+            Module.ReportError(this, $"Unexpected tower distribution: West={westTowers.Count}, East={eastTowers.Count}");
+            return;
+        }
+
+        // Assign west platform
+        AssignPlatformTowersFlexible(westTowers, westSlots, westRoles);
+
+        // Assign east platform
+        AssignPlatformTowersFlexible(eastTowers, eastSlots, eastRoles);
+    }
+
+    private PlatformRoles DetermineRoleComposition(
+        List<int> platformSlots,
+        int mtSlot, int h1Slot, int m1Slot, int r1Slot,
+        int otSlot, int h2Slot, int m2Slot, int r2Slot)
+    {
+        var roles = new PlatformRoles();
+
+        for (var i = 0; i < platformSlots.Count; ++i)
+        {
+            var slot = platformSlots[i];
+
+            // Categorize as support (tank/healer) or DPS (melee/ranged)
+            if (slot == mtSlot || slot == otSlot || slot == h1Slot || slot == h2Slot)
+            {
+                // Support role
+                roles.SupportCount++;
+                if (roles.SupportSlots[0] < 0)
+                    roles.SupportSlots[0] = slot;
+                else if (roles.SupportSlots[1] < 0)
+                    roles.SupportSlots[1] = slot;
+                else
+                    roles.Valid = false; // More than 2 supports
+            }
+            else if (slot == m1Slot || slot == m2Slot || slot == r1Slot || slot == r2Slot)
+            {
+                // DPS role
+                roles.DPSCount++;
+                if (roles.DPSSlots[0] < 0)
+                    roles.DPSSlots[0] = slot;
+                else if (roles.DPSSlots[1] < 0)
+                    roles.DPSSlots[1] = slot;
+                else
+                    roles.Valid = false; // More than 2 DPS
+            }
+        }
+
+        // Validate we have exactly 2 supports and 2 DPS
+        if (roles.SupportCount != 2 || roles.DPSCount != 2)
+            roles.Valid = false;
+
+        return roles;
+    }
+
+    private struct PlatformRoles
+    {
+        public int SupportCount;
+        public int DPSCount;
+        public int[] SupportSlots; // [0] and [1]
+        public int[] DPSSlots; // [0] and [1]
+        public bool Valid;
+
+        public PlatformRoles()
+        {
+            SupportCount = 0;
+            DPSCount = 0;
+            SupportSlots = [-1, -1];
+            DPSSlots = [-1, -1];
+            Valid = true;
+        }
+    }
+
+    private void AssignPlatformTowersFlexible(
+        List<(int index, Meteor meteor, bool isNorth)> towers,
+        List<int> platformSlots,
+        PlatformRoles roles)
+    {
+        if (towers.Count != 4 || platformSlots.Count != 4)
+        {
+            Module.ReportError(this, $"AssignPlatformTowersFlexible: tower/slot mismatch {towers.Count}/{platformSlots.Count}");
+            return;
+        }
+
+        // Get the 2 support and 2 DPS players
+        var support1 = Raid[roles.SupportSlots[0]];
+        var support2 = Raid[roles.SupportSlots[1]];
+        var dps1 = Raid[roles.DPSSlots[0]];
+        var dps2 = Raid[roles.DPSSlots[1]];
+
+        if (support1 == null || support2 == null || dps1 == null || dps2 == null)
+        {
+            Module.ReportError(this, "Cannot find all players for flexible tower assignment");
+            return;
+        }
+
+        // Determine which players are close (<10 yalms from center X=100) vs far
+        var support1Close = Math.Abs(support1.Position.X - 100) < 10;
+        var support2Close = Math.Abs(support2.Position.X - 100) < 10;
+        var dps1Close = Math.Abs(dps1.Position.X - 100) < 10;
+        var dps2Close = Math.Abs(dps2.Position.X - 100) < 10;
+
+        // Count how many of each category are close
+        var supportsCloseCount = (support1Close ? 1 : 0) + (support2Close ? 1 : 0);
+        var dpsCloseCount = (dps1Close ? 1 : 0) + (dps2Close ? 1 : 0);
+
+        // Separate towers into close and far
+        var closeTowers = new List<(int index, Meteor meteor, bool isNorth)>();
+        var farTowers = new List<(int index, Meteor meteor, bool isNorth)>();
+
+        for (var i = 0; i < towers.Count; ++i)
+        {
+            var tower = towers[i];
+            if (Math.Abs(tower.meteor.Position.X - 100) < 10)
+                closeTowers.Add(tower);
+            else
+                farTowers.Add(tower);
+        }
+
+        if (closeTowers.Count != 2 || farTowers.Count != 2)
+        {
+            closeTowers.Clear();
+            farTowers.Clear();
+            for (var i = 0; i < 2 && i < towers.Count; ++i)
+                closeTowers.Add(towers[i]);
+            for (var i = 2; i < towers.Count; ++i)
+                farTowers.Add(towers[i]);
+        }
+
+        // Find north/south in each group
+        var closeNorthList = new List<(int index, Meteor meteor, bool isNorth)>();
+        var closeSouthList = new List<(int index, Meteor meteor, bool isNorth)>();
+        var farNorthList = new List<(int index, Meteor meteor, bool isNorth)>();
+        var farSouthList = new List<(int index, Meteor meteor, bool isNorth)>();
+
+        for (var i = 0; i < closeTowers.Count; ++i)
+        {
+            var tower = closeTowers[i];
+            if (tower.isNorth)
+                closeNorthList.Add(tower);
+            else
+                closeSouthList.Add(tower);
+        }
+
+        for (var i = 0; i < farTowers.Count; ++i)
+        {
+            var tower = farTowers[i];
+            if (tower.isNorth)
+                farNorthList.Add(tower);
+            else
+                farSouthList.Add(tower);
+        }
+
+        if (closeNorthList.Count == 0 || closeSouthList.Count == 0 ||
+            farNorthList.Count == 0 || farSouthList.Count == 0)
+        {
+            Module.ReportError(this, "Platform tower layout invalid");
+            return;
+        }
+
+        var closeNorth = closeNorthList[0];
+        var closeSouth = closeSouthList[0];
+        var farNorth = farNorthList[0];
+        var farSouth = farSouthList[0];
+
+        // Determine assignment based on actual positions
+        // Standard strategy: supports north on west, DPS north on east
+        // But we adapt based on where people actually are
+
+        var closePair = new int[2];
+        var farPair = new int[2];
+
+        // Assign close/far based on actual positions (prioritize what players are doing)
+        if (supportsCloseCount == 2 && dpsCloseCount == 0)
+        {
+            // Both supports close, both DPS far
+            closePair[0] = roles.SupportSlots[0];
+            closePair[1] = roles.SupportSlots[1];
+            farPair[0] = roles.DPSSlots[0];
+            farPair[1] = roles.DPSSlots[1];
+        }
+        else if (supportsCloseCount == 0 && dpsCloseCount == 2)
+        {
+            // Both DPS close, both supports far
+            closePair[0] = roles.DPSSlots[0];
+            closePair[1] = roles.DPSSlots[1];
+            farPair[0] = roles.SupportSlots[0];
+            farPair[1] = roles.SupportSlots[1];
+        }
+        else if (supportsCloseCount == 1 && dpsCloseCount == 1)
+        {
+            // Mixed: 1 support + 1 DPS close, 1 support + 1 DPS far
+            if (support1Close)
+            {
+                closePair[0] = roles.SupportSlots[0];
+                farPair[0] = roles.SupportSlots[1];
+            }
+            else
+            {
+                closePair[0] = roles.SupportSlots[1];
+                farPair[0] = roles.SupportSlots[0];
+            }
+
+            if (dps1Close)
+            {
+                closePair[1] = roles.DPSSlots[0];
+                farPair[1] = roles.DPSSlots[1];
+            }
+            else
+            {
+                closePair[1] = roles.DPSSlots[1];
+                farPair[1] = roles.DPSSlots[0];
+            }
+        }
+        else
+        {
+            // Fallback: assume standard strategy (supports north on west)
+            closePair[0] = roles.SupportSlots[0];
+            closePair[1] = roles.DPSSlots[0];
+            farPair[0] = roles.SupportSlots[1];
+            farPair[1] = roles.DPSSlots[1];
+        }
+
+        // Assign north/south towers with swap logic
+        // Use simple heuristic: supports prefer north on west platform, DPS prefer north on east
+        _assignedTowers[closePair[0]] = ShouldSwap(closePair[0], closeNorth.index, closeSouth.index) ? closeSouth.index : closeNorth.index;
+        _assignedTowers[closePair[1]] = ShouldSwap(closePair[1], closeSouth.index, closeNorth.index) ? closeNorth.index : closeSouth.index;
+        _assignedTowers[farPair[0]] = ShouldSwap(farPair[0], farNorth.index, farSouth.index) ? farSouth.index : farNorth.index;
+        _assignedTowers[farPair[1]] = ShouldSwap(farPair[1], farSouth.index, farNorth.index) ? farNorth.index : farSouth.index;
+    }
+
+    private void AssignPlatformTowers(
+        List<(int index, Meteor meteor, bool isNorth)> towers,
+        int tankSlot, int healerSlot, int meleeSlot, int rangedSlot,
+        bool supportsNorth)
+    {
+        if (towers.Count != 4)
+        {
+            Module.ReportError(this, $"AssignPlatformTowers expected 4 towers, got {towers.Count}");
+            return;
+        }
+
+        // Separate into close (tank/melee) and far (healer/ranged) towers
+        var closeTowers = new List<(int index, Meteor meteor, bool isNorth)>();
+        var farTowers = new List<(int index, Meteor meteor, bool isNorth)>();
+
+        for (var i = 0; i < towers.Count; ++i)
+        {
+            var tower = towers[i];
+            if (Math.Abs(tower.meteor.Position.X - 100) < 10)
+                closeTowers.Add(tower);
+            else
+                farTowers.Add(tower);
+        }
+
+        if (closeTowers.Count != 2 || farTowers.Count != 2)
+        {
+            // Fallback: first 2 are close, last 2 are far
+            closeTowers.Clear();
+            farTowers.Clear();
+            for (var i = 0; i < 2 && i < towers.Count; ++i)
+                closeTowers.Add(towers[i]);
+            for (var i = 2; i < towers.Count; ++i)
+                farTowers.Add(towers[i]);
+        }
+
+        // Find north and south towers in each group
+        var closeNorthList = new List<(int index, Meteor meteor, bool isNorth)>();
+        var closeSouthList = new List<(int index, Meteor meteor, bool isNorth)>();
+        var farNorthList = new List<(int index, Meteor meteor, bool isNorth)>();
+        var farSouthList = new List<(int index, Meteor meteor, bool isNorth)>();
+
+        for (var i = 0; i < closeTowers.Count; ++i)
+        {
+            var tower = closeTowers[i];
+            if (tower.isNorth)
+                closeNorthList.Add(tower);
+            else
+                closeSouthList.Add(tower);
+        }
+
+        for (var i = 0; i < farTowers.Count; ++i)
+        {
+            var tower = farTowers[i];
+            if (tower.isNorth)
+                farNorthList.Add(tower);
+            else
+                farSouthList.Add(tower);
+        }
+
+        if (closeNorthList.Count == 0 || closeSouthList.Count == 0 ||
+            farNorthList.Count == 0 || farSouthList.Count == 0)
+        {
+            Module.ReportError(this, $"Platform tower layout invalid");
+            return;
+        }
+
+        var closeNorth = closeNorthList[0];
+        var closeSouth = closeSouthList[0];
+        var farNorth = farNorthList[0];
+        var farSouth = farSouthList[0];
+
+        // Assign based on roles and strategy
+        int tankInitial, meleeInitial, healerInitial, rangedInitial;
+
+        if (supportsNorth)
+        {
+            tankInitial = closeNorth.index;
+            meleeInitial = closeSouth.index;
+            healerInitial = farNorth.index;
+            rangedInitial = farSouth.index;
+        }
+        else
+        {
+            tankInitial = closeSouth.index;
+            meleeInitial = closeNorth.index;
+            healerInitial = farSouth.index;
+            rangedInitial = farNorth.index;
+        }
+
+        // Apply assignments with swap logic
+        _assignedTowers[tankSlot] = ShouldSwap(tankSlot, tankInitial, meleeInitial) ? meleeInitial : tankInitial;
+        _assignedTowers[meleeSlot] = ShouldSwap(meleeSlot, meleeInitial, tankInitial) ? tankInitial : meleeInitial;
+        _assignedTowers[healerSlot] = ShouldSwap(healerSlot, healerInitial, rangedInitial) ? rangedInitial : healerInitial;
+        _assignedTowers[rangedSlot] = ShouldSwap(rangedSlot, rangedInitial, healerInitial) ? healerInitial : rangedInitial;
+    }
+
+    private bool ShouldSwap(int slot, int initialTower, int partnerTower)
+    {
+        if (initialTower < 0 || initialTower >= Towers.Count)
+            return false;
+
+        var tower = Towers[initialTower];
+
+        // Check if player is forbidden from their initial tower
+        if (tower.ForbiddenSoakers[slot])
+        {
+            // Check if partner tower is available
+            if (partnerTower >= 0 && partnerTower < Towers.Count)
+            {
+                var partnerTowerData = Towers[partnerTower];
+                return !partnerTowerData.ForbiddenSoakers[slot];
+            }
+        }
+
+        return false;
     }
 
     // --------------------------------------------------------
@@ -250,15 +827,114 @@ sealed class IdyllicDreamElementalMeteor(BossModule module) : Components.Generic
 
             DrawElement(m.Element, m.Position + (m.Position - center));
         }
+
+        // Highlight assigned tower
+        var assignedTower = _assignedTowers[pcSlot];
+        if (assignedTower >= 0 && assignedTower < Towers.Count)
+        {
+            var tower = Towers[assignedTower];
+            if (tower.Shape is AOEShapeCircle circle)
+                Arena.AddCircle(tower.Position, circle.Radius, Colors.Safe, 2);
+        }
     }
 
     // --------------------------------------------------------
-    // Suppress default tower hints
+    // Tower Restrictions
     // --------------------------------------------------------
+
+    public override ReadOnlySpan<Tower> ActiveTowers(int slot, Actor actor)
+    {
+        if (!DrawIcons || Towers.Count == 0 || _assignedTowers[slot] < 0)
+            return base.ActiveTowers(slot, actor);
+
+        var assignedTower = _assignedTowers[slot];
+
+        // Create modified towers where only the assigned tower is not forbidden
+        for (var i = 0; i < Towers.Count; ++i)
+        {
+            _modifiedTowers[i] = Towers[i];
+
+            if (i == assignedTower)
+            {
+                // Assigned tower: never forbidden, ignore max soakers
+                _modifiedTowers[i].ForbiddenSoakers = default;
+                _modifiedTowers[i].MaxSoakers = int.MaxValue;
+            }
+            else
+            {
+                // Non-assigned tower: always forbidden
+                _modifiedTowers[i].ForbiddenSoakers = default(BitMask).WithBit(slot);
+            }
+        }
+
+        return _modifiedTowers.AsSpan(0, Towers.Count);
+    }
 
     public override void AddHints(int slot, Actor actor, TextHints hints)
     {
-        // intentionally suppress GenericTowers hints
+        // Provide tower assignment hints
+        var assignedTower = _assignedTowers[slot];
+        if (assignedTower >= 0 && assignedTower < Towers.Count && DrawIcons)
+        {
+            var tower = Towers[assignedTower];
+            var meteor = Meteors[assignedTower];
+
+            // Check if player is in their assigned tower
+            var inAssignedTower = tower.IsInside(actor);
+
+            // Record tower soak in shared state
+            if (inAssignedTower)
+            {
+                var sharedState = Module.FindComponent<IdyllicDreamSharedState>();
+                sharedState?.RecordTowerSoak(slot, assignedTower, meteor.Element, meteor.Position);
+            }
+
+            if (!inAssignedTower && tower.Activation > WorldState.CurrentTime)
+            {
+                hints.Add($"Go to {meteor.Element} tower!");
+            }
+
+            // Warn if in wrong tower
+            for (var i = 0; i < Towers.Count; ++i)
+            {
+                if (i != assignedTower && Towers[i].IsInside(actor))
+                {
+                    hints.Add("Wrong tower!");
+                    break;
+                }
+            }
+        }
+        else if (DrawIcons && Towers.Count > 0)
+        {
+            // Fallback: assignment failed, use base tower hints
+            base.AddHints(slot, actor, hints);
+        }
+    }
+
+    public override PlayerPriority CalcPriority(int pcSlot, Actor pc, int playerSlot, Actor player, ref uint customColor)
+    {
+        // Highlight players who should be in the same tower as pc
+        var pcTower = _assignedTowers[pcSlot];
+        var playerTower = _assignedTowers[playerSlot];
+
+        if (pcTower < 0 || playerTower < 0)
+            return PlayerPriority.Normal;
+
+        if (pcTower == playerTower)
+        {
+            customColor = Colors.Safe;
+            return PlayerPriority.Interesting; // Same tower assignment
+        }
+
+        return PlayerPriority.Normal;
+    }
+
+    // Public method to get assigned tower for LindwurmsPortent
+    public int GetAssignedTower(int slot)
+    {
+        if (slot < 0 || slot >= _assignedTowers.Length)
+            return -1;
+        return _assignedTowers[slot];
     }
 }
 
@@ -350,6 +1026,10 @@ sealed class IdyllicDreamLindwurmsDarkII(BossModule module) : Components.Generic
 
         CurrentBaits.Clear();
 
+        // Stop showing baits after activation time has passed
+        if (_sources.Count > 0 && WorldState.CurrentTime >= _sources[0].Activation)
+            return;
+
         var count = _sources.Count;
         for (var i = 0; i < count; ++i)
         {
@@ -369,11 +1049,11 @@ sealed class IdyllicDreamLindwurmsDarkII(BossModule module) : Components.Generic
 
     public override void OnEventCast(Actor caster, ActorCastEvent spell)
     {
-        if ((AID)spell.Action.ID != AID.LindwurmsDarkII)
-            return;
-
-        _sources.Clear();
-        _initialized = false;
+        if ((AID)spell.Action.ID is AID.LindwurmsDarkII or AID.CosmicKiss)
+        {
+            _sources.Clear();
+            _initialized = false;
+        }
     }
 
     public override void AddHints(int slot, Actor actor, TextHints hints)
@@ -583,12 +1263,35 @@ sealed class LindwurmsPortent(BossModule module) : Components.GenericBaitAway(mo
         public DateTime Expire;
     }
 
+    // "Giving Far" = Wind tower position, FarPortent (player has far debuff, stands here)
+    static readonly WPos WestGivingFar = new(91f, 100f);
+    static readonly WPos EastGivingFar = new(109f, 100f);
+
+    // "Giving Near" = Doom tower position, NearbyPortent (player has near debuff, stands here)
+    static readonly WPos WestGivingNear = new(93f, 94f);
+    static readonly WPos EastGivingNear = new(107f, 94f);
+
+    // "Taking Far" = Earth/Fire tower position for far baiting (player baiting far cone)
+    static readonly WPos WestTakingFar = new(86f, 109f);
+    static readonly WPos EastTakingFar = new(114f, 109f);
+
+    // "Taking Near" = Earth/Fire tower position for near baiting (player baiting near cone)
+    static readonly WPos WestTakingNear = new(89f, 95f);
+    static readonly WPos EastTakingNear = new(110f, 97f);
+
     static readonly AOEShapeCone _shape = new(60, 15.Degrees());
 
     readonly List<Portent> _sources = [];
+    readonly Dictionary<int, WPos> _assignedPositions = [];
+    readonly BitMask _nearbyPortentSlots = new();
+    readonly BitMask _farawayPortentSlots = new();
 
     public override void OnStatusGain(Actor actor, ref ActorStatus status)
     {
+        var slot = Raid.FindSlot(actor.InstanceID);
+        if (slot < 0)
+            return;
+
         switch ((SID)status.ID)
         {
             case SID.FarawayPortent:
@@ -598,6 +1301,7 @@ sealed class LindwurmsPortent(BossModule module) : Components.GenericBaitAway(mo
                     Far = true,
                     Expire = status.ExpireAt
                 });
+                _farawayPortentSlots.Set(slot);
                 break;
 
             case SID.NearbyPortent:
@@ -607,12 +1311,20 @@ sealed class LindwurmsPortent(BossModule module) : Components.GenericBaitAway(mo
                     Far = false,
                     Expire = status.ExpireAt
                 });
+                _nearbyPortentSlots.Set(slot);
                 break;
         }
     }
 
     public override void Update()
     {
+        // Calculate positions when portents are active
+        if (_sources.Count > 0)
+        {
+            _assignedPositions.Clear();
+            CalculatePositions();
+        }
+
         CurrentBaits.Clear();
 
         var sources = CollectionsMarshal.AsSpan(_sources);
@@ -627,7 +1339,7 @@ sealed class LindwurmsPortent(BossModule module) : Components.GenericBaitAway(mo
 
             if (s.Far)
             {
-                float maxDist = -1;
+                var maxDist = -1f;
                 foreach (var (_, player) in Raid.WithSlot())
                 {
                     var dist = (player.Position - sourcePos).LengthSq();
@@ -640,7 +1352,7 @@ sealed class LindwurmsPortent(BossModule module) : Components.GenericBaitAway(mo
             }
             else
             {
-                float minDist = float.MaxValue;
+                var minDist = float.MaxValue;
                 foreach (var (_, player) in Raid.WithSlot())
                 {
                     if (player == s.Source)
@@ -667,6 +1379,78 @@ sealed class LindwurmsPortent(BossModule module) : Components.GenericBaitAway(mo
         }
     }
 
+    void CalculatePositions()
+    {
+        // Get shared state to retrieve tower assignments
+        var sharedState = Module.FindComponent<IdyllicDreamSharedState>();
+        if (sharedState == null)
+            return;
+
+        foreach (var (slot, actor) in Raid.WithSlot(true))
+        {
+            var (towerIndex, element, position) = sharedState.GetTowerSoak(slot);
+            if (towerIndex < 0)
+                continue; // No tower assignment found
+
+            // Determine platform based on player's CURRENT position (after knockback)
+            var isWest = actor.Position.X < 100;
+
+            // Position is determined by the tower element, not the portent status
+            // Wind towers -> GivingFar position (after being knocked to opposite platform)
+            // Dark towers -> GivingNear position  
+            // Earth/Fire close towers -> TakingNear position
+            // Earth/Fire far towers -> TakingFar position
+
+            if (element == Element.Wind)
+            {
+                _assignedPositions[slot] = isWest ? WestGivingFar : EastGivingFar;
+            }
+            else if (element == Element.Dark)
+            {
+                _assignedPositions[slot] = isWest ? WestGivingNear : EastGivingNear;
+            }
+            else if (element is Element.Earth or Element.Fire)
+            {
+                // Determine if this Earth/Fire tower is close or far from center
+                // Close towers (X closer to 100) -> TakingNear
+                // Far towers (X further from 100) -> TakingFar
+                var distFromCenter = Math.Abs(position.X - 100);
+                var isCloseTower = distFromCenter < 10; // Adjust threshold as needed
+
+                _assignedPositions[slot] = isWest
+                    ? (isCloseTower ? WestTakingNear : WestTakingFar)
+                    : (isCloseTower ? EastTakingNear : EastTakingFar);
+            }
+        }
+    }
+
+    public override void AddHints(int slot, Actor actor, TextHints hints)
+    {
+        base.AddHints(slot, actor, hints);
+
+        // Add positional hint if config enabled
+        var config = Service.Config.Get<M12S2LindwurmConfig>();
+        if (config.ShowLindwurmsPortentHints && _assignedPositions.TryGetValue(slot, out var assignedPos))
+        {
+            var dist = (actor.Position - assignedPos).Length();
+            if (dist > 1.5f)
+                hints.Add($"Go to assigned position!");
+        }
+    }
+
+    public override void DrawArenaForeground(int pcSlot, Actor pc)
+    {
+        base.DrawArenaForeground(pcSlot, pc);
+
+        // Draw only the assigned position for this player if config enabled
+        var config = Service.Config.Get<M12S2LindwurmConfig>();
+        if (config.ShowLindwurmsPortentHints && _assignedPositions.TryGetValue(pcSlot, out var assignedPos))
+        {
+            Arena.AddCircle(assignedPos, 1, Colors.Safe);
+            Arena.AddLine(pc.Position, assignedPos, Colors.Safe);
+        }
+    }
+
     public override void OnEventCast(Actor caster, ActorCastEvent spell)
     {
         if ((AID)spell.Action.ID != AID.LindwurmsThunderII)
@@ -674,5 +1458,8 @@ sealed class LindwurmsPortent(BossModule module) : Components.GenericBaitAway(mo
 
         NumCasts++;
         _sources.Clear();
+        _assignedPositions.Clear();
+        _nearbyPortentSlots.Reset();
+        _farawayPortentSlots.Reset();
     }
 }

--- a/BossMod/Modules/Dawntrail/Savage/M12SP2Lindwurm/M12S2LindwurmConfig.cs
+++ b/BossMod/Modules/Dawntrail/Savage/M12SP2Lindwurm/M12S2LindwurmConfig.cs
@@ -55,6 +55,12 @@ public sealed class M12S2LindwurmConfig : ConfigNode
         Replication3Role.Defam4
     ];
 
+    [PropertyDisplay("Attempt to adjust Idyllic Dream tower logic to mistakes")]
+    public bool IdyllicDreamAdjustToMistakes = true;
+
+    [PropertyDisplay("Show Lindwurm's Portent positional hints based on towers taken")]
+    public bool ShowLindwurmsPortentHints = true;
+
     // ============================================================
     // Effective Runtime Views (USED BY MODULE CODE)
     // ============================================================
@@ -232,6 +238,7 @@ public record struct ReplicatedCloneOrder(Cardinal Group, int Order)
 
 public enum Element
 {
+    None,
     Wind,
     Dark,
     Earth,

--- a/BossMod/Modules/Dawntrail/Savage/M12SP2Lindwurm/M12S2LindwurmEnums.cs
+++ b/BossMod/Modules/Dawntrail/Savage/M12SP2Lindwurm/M12S2LindwurmEnums.cs
@@ -15,10 +15,10 @@ public enum OID : uint
     ManaSpherePurpleBowtie = 0x4B08, // R0.600, x0 (spawn during fight)
     ManaSphereOrangeBowtie = 0x4B09, // R0.600, x0 (spawn during fight)
 
-    MeteorWind = 0x1EBF25,
-    MeteorDark = 0x1EBF26,
-    MeteorEarth = 0x1EBF27,
-    MeteorFire = 0x1EBF28,
+    MeteorDark = 0x1EBF26, // R0.500, x0 (spawn during fight), EventObj type
+    MeteorWind = 0x1EBF25, // R0.500, x0 (spawn during fight), EventObj type
+    MeteorFire = 0x1EBF28, // R0.500, x0 (spawn during fight), EventObj type
+    MeteorEarth = 0x1EBF27, // R0.500, x0 (spawn during fight), EventObj type
     TemporalTear = 0x4B0B, // R1.000, x0 (spawn during fight)
 }
 

--- a/BossMod/Modules/Dawntrail/Savage/M12SP2Lindwurm/M12S2LindwurmStates.cs
+++ b/BossMod/Modules/Dawntrail/Savage/M12SP2Lindwurm/M12S2LindwurmStates.cs
@@ -232,6 +232,7 @@ class M12S2LindwurmStates : StateMachineBuilder
         Cast(id + 0x230, (uint)AID.TwistedVision, 3.6f, 4)
             .ExecOnEnter<IdyllicDreamArena>(p => p.Predict(8.8f))
             .ExecOnEnter<IdyllicDreamElementalMeteor>(m => m.CreateTowers())
+            .ActivateOnEnter<IdyllicDreamSharedState>()
             .ActivateOnEnter<IdyllicDreamLindwurmsDarkII>()
             .ActivateOnEnter<IdyllicDreamWindTower>()
             .ActivateOnEnter<IdyllicDreamHotBlooded>()
@@ -255,6 +256,7 @@ class M12S2LindwurmStates : StateMachineBuilder
             .DeactivateOnExit<LindwurmsPortent>()
             .DeactivateOnExit<IdyllicDreamHotBlooded>()
             .DeactivateOnExit<IdyllicDreamDoom>()
+            .DeactivateOnExit<IdyllicDreamSharedState>()
             .ExecOnExit<IdyllicDreamPowerGusherSnakingKick>(k =>
             {
                 //k.Visible = true;

--- a/BossMod/PartyRolesManager.cs
+++ b/BossMod/PartyRolesManager.cs
@@ -1,0 +1,84 @@
+namespace BossMod;
+
+// manager that handles automatic party role assignment when entering duties
+public sealed class PartyRolesManager : IDisposable
+{
+    private readonly WorldState _ws;
+    private readonly PartyRolesConfig _config;
+    private readonly EventSubscriptions _subscriptions;
+    private ushort _lastZone;
+    private bool _pendingAutoAssign;
+    private DateTime _autoAssignDeadline;
+
+    public PartyRolesManager(WorldState ws)
+    {
+        _ws = ws;
+        _config = Service.Config.Get<PartyRolesConfig>();
+        _lastZone = ws.CurrentZone;
+
+        _subscriptions = new(
+            ws.CurrentZoneChanged.Subscribe(OnZoneChanged)
+        );
+    }
+
+    public void Dispose()
+    {
+        _subscriptions.Dispose();
+    }
+
+    public void Update()
+    {
+        if (!_pendingAutoAssign)
+            return;
+
+        // check if we've exceeded the deadline
+        if (_ws.CurrentTime >= _autoAssignDeadline)
+        {
+            Service.Log($"[PartyRoles] Auto-assign timeout reached, assigning with current party state");
+            _config.AutoAssignRoles(_ws.Party);
+            _pendingAutoAssign = false;
+            return;
+        }
+
+        // check if all party members have valid actors
+        var allValid = true;
+        for (var i = 0; i < PartyState.MaxPartySize; ++i)
+        {
+            ref var m = ref _ws.Party.Members[i];
+            if (m.IsValid() && m.ContentId != 0)
+            {
+                var actor = _ws.Party[i];
+                if (actor == null)
+                {
+                    allValid = false;
+                    break;
+                }
+            }
+        }
+
+        if (allValid)
+        {
+            Service.Log($"[PartyRoles] All party members valid, auto-assigning roles");
+            _config.AutoAssignRoles(_ws.Party);
+            _pendingAutoAssign = false;
+        }
+    }
+
+    private void OnZoneChanged(WorldState.OpZoneChange op)
+    {
+        if (!_config.AutoAssignOnDutyEnter)
+        {
+            _lastZone = op.Zone;
+            return;
+        }
+
+        if (_lastZone != op.Zone && _lastZone != 0)
+        {
+            Service.Log($"[PartyRoles] Entering duty, scheduling auto-assign roles");
+            _pendingAutoAssign = true;
+            _autoAssignDeadline = _ws.CurrentTime.AddSeconds(5); // 5 second timeout
+        }
+
+        _lastZone = op.Zone;
+    }
+}


### PR DESCRIPTION
- Fixed Wind tower not being displayed and knockback not showing
- Reworked Tower mechanic to assign towers to players and automatically adjust based on Light debuff
- Fixed Dark tower baited AOE being displayed much longer than it needed to be
- Fixed Earth tower delayed AOE not being displayed
- Fixed baited AOEs for Nearby and Faraway Portent not displaying properly
- Added static position hints for resolving Nearby/Faraway Portent mechanic based on towers taken

- Added logic for automatically asssigning players to specific role slots in the Party Role Assignments menu
- Added an option to auto assign on entering a duty