### PR TITLE
Third walk - Boss 3 fixes

### DIFF
--- a/BossMod/Modules/Dawntrail/Alliance/A34Promathia/A34Promathia.cs
+++ b/BossMod/Modules/Dawntrail/Alliance/A34Promathia/A34Promathia.cs
@@ -1,4 +1,6 @@
 ﻿using BossMod.Autorotation.xan;
+using FFXIVClientStructs.FFXIV.Client.UI;
+using TerraFX.Interop.DirectX;
 
 namespace BossMod.Dawntrail.Alliance.A34Promathia;
 
@@ -64,7 +66,16 @@ sealed class BastionOfTwilight(BossModule module) : Components.GenericAOEs(modul
 
 sealed class PestilentPenance(BossModule module) : Components.SimpleAOEs(module, (uint)AID.PestilentPenance, new AOEShapeRect(50f, 25f));
 
-sealed class Comet(BossModule module) : Components.SpreadFromIcon(module, (uint)IconID.Comet, (uint)AID.Comet, 6f, 4d);
+sealed class Comet(BossModule module) : Components.SpreadFromIcon(module, (uint)IconID.Comet, (uint)AID.Comet, 6f, 4d)
+{
+    public override void OnCastFinished(Actor caster, ActorCastInfo spell)
+    {
+        if (spell.Action.ID is (uint)AID.Meteor1 or (uint)AID.Meteor2) // Hey guess what?  The tankbuster in meteor is actually just Comet again!
+        {
+            Spreads.Clear();
+        }
+    }
+}
 
 sealed class FalseGenesis(BossModule module) : BossComponent(module)
 {
@@ -140,16 +151,19 @@ sealed class AuroralDrape(BossModule module) : Components.SimpleAOEs(module, (ui
 sealed class WindsOfPromyvion(BossModule module) : Components.GenericRotatingAOE(module)
 {
     private readonly AOEShapeRect _rect = new(16f, 3f);
+    private Actor? _caster;
 
     public override void OnEventIcon(Actor actor, uint iconID, ulong targetID)
     {
         if (iconID == (uint)IconID.WindsLeft)
         {
             Sequences.Add(new(_rect, actor.Position, actor.Rotation, 30.Degrees(), WorldState.FutureTime(4.5d), 1.4d, 4));
+            _caster = actor;
         }
         if (iconID == (uint)IconID.WindsRight)
         {
             Sequences.Add(new(_rect, actor.Position, actor.Rotation, -30.Degrees(), WorldState.FutureTime(4.5d), 1.4d, 4));
+            _caster = actor;
         }
     }
     public override void OnEventCast(Actor caster, ActorCastEvent spell)
@@ -157,6 +171,17 @@ sealed class WindsOfPromyvion(BossModule module) : Components.GenericRotatingAOE
         if (spell.Action.ID is (uint)AID.WindsOfPromyvionCast or (uint)AID.WindsOfPromyvionSpam)
         {
             AdvanceSequence(0, WorldState.CurrentTime);
+        }
+    }
+    public override void OnActorRenderflagsChange(Actor actor, int renderflags)
+    {
+        if (_caster != null)
+        {
+            if (actor.InstanceID == _caster.InstanceID && renderflags == 16384)
+            {
+                Sequences.Clear();
+                Update();
+            }
         }
     }
 }
@@ -204,21 +229,19 @@ sealed class EmptySeed(BossModule module) : Components.SimpleKnockbacks(module, 
             return;
         for (var i = 0; i < Casters.Count; i++)
         {
-            //var cone = new AOEShapeCone(3f, 22.5f.Degrees(), invertForbiddenZone: true);
-            var corners = new WPos[4];
             var source = Casters[i].Origin;
-            var firstcornerdir = PlatformOrientation(source) + 45.Degrees();
-            for (var j = 0; j < corners.Length; j++)
+            if (actor.DistanceToPoint(source) < 9f)
             {
-                var angle = firstcornerdir + j * 90f.Degrees();
+                var firstcornerdir = PlatformOrientation(source) + 45.Degrees();
+                var angle = firstcornerdir;
                 var corner = source + angle.ToDirection() * 9f;
-                corners[j] = corner;
                 hints.AddForbiddenZone(new SDInvertedCone(corner, 5f, angle + 180.Degrees(), 22.5f.Degrees()));
             }
-
         }
-    }
+
+   }
 }
+
 sealed class MalevolentBlessingCone(BossModule module) : Components.SimpleAOEs(module, (uint)AID.MalevolentBlessingCone, new AOEShapeCone(40f, 11.5f.Degrees()));
 
 sealed class MalevolentBlessingRect(BossModule module) : Components.SimpleAOEs(module, (uint)AID.MalevolentBlessingRect, new AOEShapeRect(50f, 25f));
@@ -229,64 +252,7 @@ sealed class InfernalDeliveranceTower(BossModule module) : Components.CastTowers
 
 sealed class InfernalDeliveranceAOE(BossModule module) : Components.SimpleAOEs(module, (uint)AID.InfernalDeliveranceAOE, 8f);
 
-sealed class Meteor(BossModule module) : Components.SpreadFromIcon(module, (uint)IconID.Meteor, (uint)AID.Meteor1, 6f, 5f)
-{
-    public override void OnEventCast(Actor caster, ActorCastEvent spell)
-    {
-        var aid = spell.Action.ID;
-        if (aid == StackAction)
-        {
-            var id = spell.MainTargetID;
-            if (MaxCasts != 1 && Stacks.Count == 1 && Stacks.Ref(0).Target.InstanceID != id) // multi hit stack target died and new target got selected
-            {
-                Stacks.Ref(0).Target = WorldState.Actors.Find(id)!;
-            }
-            if (++CastCounter == MaxCasts)
-            {
-                var count = Stacks.Count;
-                var stacks = CollectionsMarshal.AsSpan(Stacks);
-                for (var i = 0; i < count; ++i)
-                {
-                    if (stacks[i].Target.InstanceID == id)
-                    {
-                        ++NumFinishedStacks;
-                        CastCounter = 0;
-                        Stacks.RemoveAt(i);
-                        return;
-                    }
-                }
-                // stack not found, probably due to being self targeted
-                if (count != 0)
-                {
-                    ++NumFinishedStacks;
-                    CastCounter = 0;
-                    Stacks.RemoveAt(0);
-                }
-            }
-        }
-        else if (aid == SpreadAction || aid == (uint)AID.Meteor2)
-        {
-            var count = Spreads.Count;
-            var id = spell.MainTargetID;
-            var spreads = CollectionsMarshal.AsSpan(Spreads);
-            for (var i = 0; i < count; ++i)
-            {
-                if (spreads[i].Target.InstanceID == id)
-                {
-                    Spreads.RemoveAt(i);
-                    ++NumFinishedSpreads;
-                    return;
-                }
-            }
-            // spread not found, probably due to being self targeted
-            if (count != 0)
-            {
-                ++NumFinishedSpreads;
-                Spreads.RemoveAt(0);
-            }
-        }
-    }
-}
+sealed class Meteor(BossModule module) : Components.SpreadFromIcon(module, (uint)IconID.Meteor, (uint)AID.Meteor2, 6f, 5f);  // this is the regular spreads only, Tankbuster is handled in Comet.
 
 sealed class DeadlyRebirth(BossModule module) : Components.RaidwideCast(module, (uint)AID.DeadlyRebirth);
 

--- a/BossMod/Modules/Dawntrail/Alliance/A34Promathia/A34Promathia.cs
+++ b/BossMod/Modules/Dawntrail/Alliance/A34Promathia/A34Promathia.cs
@@ -1,8 +1,4 @@
-﻿using BossMod.Autorotation.xan;
-using FFXIVClientStructs.FFXIV.Client.UI;
-using TerraFX.Interop.DirectX;
-
-namespace BossMod.Dawntrail.Alliance.A34Promathia;
+﻿namespace BossMod.Dawntrail.Alliance.A34Promathia;
 
 sealed class EmptySalvation(BossModule module) : Components.RaidwideCast(module, (uint)AID.EmptySalvation);
 

--- a/BossMod/Modules/Dawntrail/Alliance/A34Promathia/A34PromathiaEnums.cs
+++ b/BossMod/Modules/Dawntrail/Alliance/A34Promathia/A34PromathiaEnums.cs
@@ -30,7 +30,7 @@ public enum AID : uint
     WheelOfImpregnabilityFire = 50323, // EmptyThinker->self, no cast, range 13 circle
     BastionOfTwilightCast = 50322, // Promathia->self, 2.0+1.0s cast, single-target
     PestilentPenanceCastbar = 50330, // Promathia->self, 6.4+0.6s cast, single-target
-    BastionOfTwilightFire = 50324, // EmptyThinker->self, no cast, range ?-50 donut
+    BastionOfTwilightFire = 50324, // EmptyThinker->self, no cast, range 8-50 donut
     PestilentPenance = 50331, // EmptyThinker->self, 7.0s cast, range 50 width 50 rect
     FleetingEternity1 = 50319, // Promathia->self, 3.5+1.0s cast, single-target
     CometCastbar = 50337, // Promathia->self, 4.5+0.5s cast, single-target


### PR DESCRIPTION
More Promathia fixes!

- If you kill an add during the rotational AOE, the AOE will disappear properly when it despawns.
- Adds knockback AI handling improved - generates one safe cone per platform to hide in.
- Turns out the tankbuster Meteors were comets all along!  They should clear properly when they hit.