### PR TITLE
M12S P2 Replication 1: Static strategy

### DIFF
--- a/BossMod/Modules/Dawntrail/Savage/M12SP2Lindwurm/M12S2LindwurmConfig.cs
+++ b/BossMod/Modules/Dawntrail/Savage/M12SP2Lindwurm/M12S2LindwurmConfig.cs
@@ -19,7 +19,10 @@ public sealed class M12S2LindwurmConfig : ConfigNode
         CloneRelative,
 
         [PropertyDisplay("DN")]
-        DN
+        DN,
+
+        [PropertyDisplay("Static")]
+        Static
     }
 
     public readonly struct Replication1Effective(Replication1Strategy strat)
@@ -28,6 +31,8 @@ public sealed class M12S2LindwurmConfig : ConfigNode
 
         public bool IsCloneRelative => Strategy == Replication1Strategy.CloneRelative;
         public bool IsDN => Strategy == Replication1Strategy.DN;
+
+        public bool IsStatic => Strategy == Replication1Strategy.Static;
     }
 
     // ============================================================

--- a/BossMod/Modules/Dawntrail/Savage/M12SP2Lindwurm/M12S2LindwurmStates.cs
+++ b/BossMod/Modules/Dawntrail/Savage/M12SP2Lindwurm/M12S2LindwurmStates.cs
@@ -26,7 +26,7 @@ class M12S2LindwurmStates : StateMachineBuilder
 
         Cast(id + 0x100, (uint)AID.Replication, 9.5f, 3)
             .ActivateOnEnter<Replication1SecondBait>()
-            .ActivateOnEnter<Replication1CloneRelativeGuidance>()
+            .ActivateOnEnter<Replication1Guidance>()
             .ActivateOnEnter<WingedScourge>()
             .ActivateOnEnter<WingedScourgeSecond>()
             .ActivateOnEnter<MightyMagicTopTierSlamFirstBait>()
@@ -51,7 +51,7 @@ class M12S2LindwurmStates : StateMachineBuilder
         ComponentCondition<MightyMagicTopTierSlamSecondBait>(id + 0x142, 0.3f, b => b.NumDark > 0, "Dark baits")
             .DeactivateOnExit<MightyMagicTopTierSlamSecondBait>()
             .DeactivateOnExit<Replication1SecondBait>()
-            .DeactivateOnExit<Replication1CloneRelativeGuidance>()
+            .DeactivateOnExit<Replication1Guidance>()
             .DeactivateOnExit<WingedScourge>();
 
         DoubleSobat(id + 0x200, 2.4f);

--- a/BossMod/Modules/Dawntrail/Savage/M12SP2Lindwurm/Replication1.cs
+++ b/BossMod/Modules/Dawntrail/Savage/M12SP2Lindwurm/Replication1.cs
@@ -593,7 +593,7 @@ sealed class EsotericFinisher : Components.GenericBaitAway
     }
 }
 
-sealed class Replication1CloneRelativeGuidance : BossComponent
+sealed class Replication1Guidance : BossComponent
 {
     const float InitialRadius = 7.5f;
     const float PairOffset = 2.25f;
@@ -631,7 +631,7 @@ sealed class Replication1CloneRelativeGuidance : BossComponent
     static readonly int[] OrderNESW = [0, 1, 2, 3];
     static readonly int[] OrderWSEN = [3, 2, 1, 0];
 
-    public Replication1CloneRelativeGuidance(BossModule module) : base(module)
+    public Replication1Guidance(BossModule module) : base(module)
     {
         _bait = module.FindComponent<Replication1SecondBait>()!;
         _assignments = _prc.AssignmentsPerSlot(Module.WorldState.Party);
@@ -835,6 +835,18 @@ sealed class Replication1CloneRelativeGuidance : BossComponent
                              out var nearDark, out var farDark))
             return null;
 
+        if (_rep1.IsStatic)
+        {
+            return StaticFinalPosition(slot, actor, farDark);
+        }
+        else
+        {
+            return CloneRelativeOrDNFinalPosition(slot, actor, nearFire, farFire, nearDark, farDark);
+        }
+    }
+
+    WPos? CloneRelativeOrDNFinalPosition(int slot, Actor actor, WPos nearFire, WPos farFire, WPos nearDark, WPos farDark)
+    {
         var assign = _assignments[slot];
         var mech = BaitType(actor);
 
@@ -898,6 +910,7 @@ sealed class Replication1CloneRelativeGuidance : BossComponent
         }
         else
         {
+            // Clone Relative (Static handled earlier)
             targetDark = support ? ccwDark : cwDark;
         }
 
@@ -911,6 +924,87 @@ sealed class Replication1CloneRelativeGuidance : BossComponent
     }
 
     // ------------------------------------------------------------
+    // STATIC STRATEGY
+    // ------------------------------------------------------------
+    //
+    // The dark clone closest to the wall (= farDark) defines a "new North".
+    // All 8 safe spots are expressed as offsets in that rotated local frame,
+    // where +Z = toward farDark (new North) and +X = 90° clockwise (new East).
+    //
+    // 3 spots reuse the existing Outer[] radius (distance 14 from center):
+    //   - H2/R2 dark  → relative-N outer
+    //   - H1/R1 dark  → relative-W outer
+    //   - H1/R1 + H2/R2 fire → SW outer corner (stacked)
+    //
+    // The remaining 4 inner spots are hand-tuned constants and may need
+    // in-game adjustment against the reference image.
+    //
+
+    const float StaticOuterRadius = 14f; // same magnitude as Outer[] markers
+
+    // Offsets in the new-north frame (X = new-east, Z = new-north).
+    static readonly WDir StaticH1R1Dark = new(-StaticOuterRadius, 0);                 // rel-W outer
+    static readonly WDir StaticH2R2Dark = new(0, StaticOuterRadius);                  // rel-N outer
+    static readonly WDir StaticRangedFire = new(-StaticOuterRadius * 0.5f, -StaticOuterRadius * 0.5f); // rel-SW outer (H1/R1 + H2/R2 stacked)
+
+    // Hand-tuned inner spots.
+    static readonly WDir StaticMTM1Fire = new(0, 1.5f);    // center, on northern line of center box
+    static readonly WDir StaticOTM2Fire = new(3f, 1.5f);   // east of center, on northern line
+    static readonly WDir StaticMTM1Dark = new(-3f, 3f);    // rel-NW inner, one box below new-north white line
+    static readonly WDir StaticOTM2Dark = new(3f, 3f);     // rel-NE inner, one box below new-north white line
+
+    bool BuildNewNorthBasis(WPos farDark, out WDir north, out WDir east)
+    {
+        var v = farDark - Center;
+        var lenSq = v.LengthSq();
+        if (lenSq < 0.0001f)
+        {
+            north = default;
+            east = default;
+            return false;
+        }
+        north = v / MathF.Sqrt(lenSq);
+        east = new WDir(-north.Z, north.X); // 90° clockwise
+        return true;
+    }
+
+    WPos? StaticFinalPosition(int slot, Actor actor, WPos farDark)
+    {
+        if (!BuildNewNorthBasis(farDark, out var north, out var east))
+            return null;
+
+        var assign = _assignments[slot];
+        var mech = BaitType(actor);
+
+        WDir local = (assign, mech) switch
+        {
+            // Dark baits
+            (PartyRolesConfig.Assignment.H1, Replication1SecondBait.Assignment.Dark) => StaticH1R1Dark,
+            (PartyRolesConfig.Assignment.R1, Replication1SecondBait.Assignment.Dark) => StaticH1R1Dark,
+            (PartyRolesConfig.Assignment.H2, Replication1SecondBait.Assignment.Dark) => StaticH2R2Dark,
+            (PartyRolesConfig.Assignment.R2, Replication1SecondBait.Assignment.Dark) => StaticH2R2Dark,
+            (PartyRolesConfig.Assignment.MT, Replication1SecondBait.Assignment.Dark) => StaticMTM1Dark,
+            (PartyRolesConfig.Assignment.M1, Replication1SecondBait.Assignment.Dark) => StaticMTM1Dark,
+            (PartyRolesConfig.Assignment.OT, Replication1SecondBait.Assignment.Dark) => StaticOTM2Dark,
+            (PartyRolesConfig.Assignment.M2, Replication1SecondBait.Assignment.Dark) => StaticOTM2Dark,
+
+            // Fire baits
+            (PartyRolesConfig.Assignment.MT, Replication1SecondBait.Assignment.Fire) => StaticMTM1Fire,
+            (PartyRolesConfig.Assignment.M1, Replication1SecondBait.Assignment.Fire) => StaticMTM1Fire,
+            (PartyRolesConfig.Assignment.OT, Replication1SecondBait.Assignment.Fire) => StaticOTM2Fire,
+            (PartyRolesConfig.Assignment.M2, Replication1SecondBait.Assignment.Fire) => StaticOTM2Fire,
+            (PartyRolesConfig.Assignment.H1, Replication1SecondBait.Assignment.Fire) => StaticRangedFire,
+            (PartyRolesConfig.Assignment.R1, Replication1SecondBait.Assignment.Fire) => StaticRangedFire,
+            (PartyRolesConfig.Assignment.H2, Replication1SecondBait.Assignment.Fire) => StaticRangedFire,
+            (PartyRolesConfig.Assignment.R2, Replication1SecondBait.Assignment.Fire) => StaticRangedFire,
+
+            _ => default
+        };
+
+        return Center + local.X * east + local.Z * north;
+    }
+
+    // ------------------------------------------------------------
     // DRAW
     // ------------------------------------------------------------
 
@@ -918,6 +1012,10 @@ sealed class Replication1CloneRelativeGuidance : BossComponent
     {
         if (_assignments.Length != 8)
             return;
+
+        // Mark the wall-dark clone as "new North" for Static strategy.
+        if (_rep1.IsStatic && TryGetFormation(out _, out _, out _, out var farDark))
+            Arena.AddCircle(farDark, 1.25f, Colors.Object);
 
         var pos = DebuffsAssigned()
             ? FinalPosition(pcSlot, pc)

--- a/BossMod/Modules/Dawntrail/Savage/M12SP2Lindwurm/Replication1.cs
+++ b/BossMod/Modules/Dawntrail/Savage/M12SP2Lindwurm/Replication1.cs
@@ -602,6 +602,8 @@ sealed class Replication1Guidance : BossComponent
     // Spread-marker radius (matches UniformStackSpread(module, 5, 5) used by the bait components).
     const float StaticSpreadRadius = 5f;
 
+    const float StaticWaymarkRadius = 13.65f;
+
     readonly Replication1SecondBait _bait;
     readonly PartyRolesConfig _prc = Service.Config.Get<PartyRolesConfig>();
     readonly PartyRolesConfig.Assignment[] _assignments;
@@ -632,6 +634,12 @@ sealed class Replication1Guidance : BossComponent
     // DN selection orders (no stackalloc)
     static readonly int[] OrderNESW = [0, 1, 2, 3];
     static readonly int[] OrderWSEN = [3, 2, 1, 0];
+
+    // Static strategy offsets in the new-north frame (X = rel-East, Z = rel-North).
+    static readonly WDir StaticH2R2Fire = StaticWaymarkRadius * new WDir(1f, 1f).Normalized(); // rel-NE flank (right) = A@4
+    static readonly WDir StaticH1R1Fire = StaticWaymarkRadius * new WDir(-1f, 1f).Normalized(); // rel-NW flank (left)  = D@4
+    static readonly WDir StaticRangedDark = StaticWaymarkRadius * new WDir(-1f, -1f).Normalized(); // rel-SW behind-left  = C@4
+    static readonly WDir StaticMeleeFire = new(0f, 1.5f); // baits fire: stack on the center box's north line
 
     public Replication1Guidance(BossModule module) : base(module)
     {
@@ -711,11 +719,11 @@ sealed class Replication1Guidance : BossComponent
     // Fire stacks group up:  Melee M1/M2 share an SE point, Tanks MT/OT share an NW point (single shared point each).
     // Dark spreads fan out:  Ranged R1/R2 around NE, Healers H1/H2 around SW, pushed out to the edge of
     //                        their spread marker (InitialRadius + StaticSpreadRadius) and split by PairOffset.
-    WPos StaticInitialPosition(PartyRolesConfig.Assignment a)
+    WPos StaticInitialPosition(PartyRolesConfig.Assignment assignment)
     {
         var edgeRadius = InitialRadius + StaticSpreadRadius; // 12.5
 
-        var (angleDeg, radius, splitSign) = a switch
+        var (angleDeg, radius, splitSign) = assignment switch
         {
             PartyRolesConfig.Assignment.M1 or PartyRolesConfig.Assignment.M2 => (45f, InitialRadius, 0f),    // SE stack
             PartyRolesConfig.Assignment.MT or PartyRolesConfig.Assignment.OT => (-135f, InitialRadius, 0f),  // NW stack
@@ -975,14 +983,6 @@ sealed class Replication1Guidance : BossComponent
     //                                OT/M2 right (rel-East), away from the stacked fire-baiters.
     //   - Dark debuff (baits fire) → stack both together on the center box's north line.
 
-    const float StaticWaymarkRadius = 13.65f;      // A/B/C/D cardinal waymark distance from center
-
-    // Offsets in the new-north frame (X = rel-East, Z = rel-North).
-    static readonly WDir StaticH2R2Fire = StaticWaymarkRadius * new WDir(1f, 1f).Normalized(); // rel-NE flank (right) = A@4
-    static readonly WDir StaticH1R1Fire = StaticWaymarkRadius * new WDir(-1f, 1f).Normalized(); // rel-NW flank (left)  = D@4
-    static readonly WDir StaticRangedDark = StaticWaymarkRadius * new WDir(-1f, -1f).Normalized(); // rel-SW behind-left  = C@4
-    static readonly WDir StaticMeleeFire = new(0f, 1.5f); // baits fire: stack on the center box's north line
-
     bool BuildNewNorthBasis(WPos farDark, out WDir north, out WDir east)
     {
         var v = farDark - Center;
@@ -998,9 +998,9 @@ sealed class Replication1Guidance : BossComponent
         return true;
     }
 
-    static bool IsMeleeOrTank(PartyRolesConfig.Assignment a)
-        => a is PartyRolesConfig.Assignment.MT or PartyRolesConfig.Assignment.OT
-              or PartyRolesConfig.Assignment.M1 or PartyRolesConfig.Assignment.M2;
+    static bool IsMeleeOrTank(PartyRolesConfig.Assignment assignment)
+        => assignment is PartyRolesConfig.Assignment.MT or PartyRolesConfig.Assignment.OT
+                      or PartyRolesConfig.Assignment.M1 or PartyRolesConfig.Assignment.M2;
 
     WPos? StaticFinalPosition(int slot, Actor actor, WPos farDark)
     {
@@ -1009,26 +1009,25 @@ sealed class Replication1Guidance : BossComponent
 
         var assign = _assignments[slot];
 
-        // Baits dark ⇔ does NOT have Dark Resistance Down (i.e. has Fire Resistance Down, or none yet).
+        // Baits dark - does NOT have Dark Resistance Down (i.e. has Fire Resistance Down, or none yet).
         // Use BaitType so this matches the shared logic and doesn't depend on positively reading the
-        // fire debuff — relying on the dark debuff's absence is robust to timing/detection gaps.
+        // fire debuff - relying on the dark debuff's absence is robust to timing/detection gaps.
         var isDark = BaitType(actor) == Replication1SecondBait.Assignment.Dark;
 
-        // Melee/tank with the FIRE debuff (baits dark): stand on the boss's edge in melee range,
-        // split MT/M1 left (rel-West), OT/M2 right (rel-East), away from the stacked fire-baiters.
+        // Melee/tank with the FIRE debuff (baits dark): stand on the boss's edge in melee range
         if (isDark && IsMeleeOrTank(assign))
         {
             var boss = Module.PrimaryActor;
             var side = assign is PartyRolesConfig.Assignment.MT or PartyRolesConfig.Assignment.M1 ? -1f : 1f;
             // On the boss on the correct side (MT/M1 left, OT/M2 right), keeping the bait/jump clear of the other
             // players' circles: the dark-melee stack (north), the other side melee, and the ranged waymark spots.
-            WPos ToWorld(WDir o) => Center + o.X * east + o.Z * north;
+            WPos ToWorld(WDir offset) => Center + offset.X * east + offset.Z * north;
             var otherMelee = boss.Position + boss.HitboxRadius * (-side) * east;
             Span<WPos> circles = [ToWorld(StaticMeleeFire), otherMelee, ToWorld(StaticRangedDark), ToWorld(StaticH1R1Fire), ToWorld(StaticH2R2Fire)];
             return MeleeEdgeSpot(slot, actor, side * east, boss, circles, StaticSpreadRadius);
         }
 
-        WDir local = (assign, isDark) switch
+        WDir roleBasedPosition = (assign, isDark) switch
         {
             // Dark baits — ranged/healers share the behind-left cardinal waymark
             (PartyRolesConfig.Assignment.H1, true) or (PartyRolesConfig.Assignment.R1, true) or
@@ -1045,59 +1044,61 @@ sealed class Replication1Guidance : BossComponent
             _ => default
         };
 
-        var spot = Center + local.X * east + local.Z * north;
+        var spot = Center + roleBasedPosition.X * east + roleBasedPosition.Z * north;
         return AvoidCones(spot, slot, actor);
     }
 
-    // Signed-distance fields for the active red-clone cones (WingedScourgeSecond). Negative = inside a cone.
-    ShapeDistance[] ConeHazards(int slot, Actor actor)
+    // Builds a signed-distance field per currently-active fire clone cone (WingedScourgeSecond), so a point
+    // can be cheaply tested against all of them. Each field returns negative inside its cone, positive outside.
+    // Returns an empty array when no cones are active.
+    ShapeDistance[] FireCloneConeFields(int slot, Actor actor)
     {
         var ws = Module.FindComponent<WingedScourgeSecond>();
         var cones = ws != null ? ws.ActiveAOEs(slot, actor) : default;
 
-        var sd = new ShapeDistance[cones.Length];
+        var fields = new ShapeDistance[cones.Length];
         for (var i = 0; i < cones.Length; ++i)
-            sd[i] = cones[i].Shape.Distance(cones[i].Origin, cones[i].Rotation);
-        return sd;
+            fields[i] = cones[i].Shape.Distance(cones[i].Origin, cones[i].Rotation);
+        return fields;
     }
 
     // Nudge a static safe spot out of the active cones, keeping it as close to the marker as possible.
     WPos AvoidCones(WPos spot, int slot, Actor actor)
     {
-        var sd = ConeHazards(slot, actor);
-        if (sd.Length == 0)
+        var coneFields = FireCloneConeFields(slot, actor);
+        if (coneFields.Length == 0)
             return spot;
 
-        const float cushion = 2f;   // stay clearly outside the shape
-        if (ConeClear(sd, spot, cushion))
+        const float cushion = 2f;   // stay clearly outside the cone
+        if (IsClearOf(coneFields, spot, cushion))
             return spot;
 
-        // Nearest-safe search: smallest displacement that clears every hazard.
+        // Nearest-safe search: smallest displacement that clears every cone.
         const float maxNudge = 10f;
         const int dirs = 24;
         for (var r = 0.5f; r <= maxNudge; r += 0.5f)
             for (var d = 0; d < dirs; ++d)
             {
                 var cand = spot + r * (d * (360f / dirs)).Degrees().ToDirection();
-                if (ConeClear(sd, cand, cushion))
+                if (IsClearOf(coneFields, cand, cushion))
                     return cand;
             }
 
         return spot; // no safe spot within range — leave it on the marker
     }
 
-    // The melee's spot: ON the boss (hitbox edge) on the correct side — tight uptime, just outside the central
-    // stack. It edges outward only as far as max melee if the close ring is blocked, sweeping around the boss so
-    // its bait/jump stays clear of the other players' circles. Cones are NOT dodged (one cone may clip by design).
+    // The melee's spot: ON the boss (hitbox edge) on the correct side — tight uptime, just outside the central stack.
+    // It edges outward only as far as max melee if the close ring is blocked, sweeping around the boss so
+    // its bait/jump stays clear of the other players' circles.
     WPos MeleeEdgeSpot(int slot, Actor actor, WDir baseDir, Actor boss, ReadOnlySpan<WPos> avoidCircles, float circleRadius)
     {
         var baseAngle = baseDir.ToAngle();
-        var circleSD = new ShapeDistance[avoidCircles.Length];
+        var circleFields = new ShapeDistance[avoidCircles.Length];
         for (var j = 0; j < avoidCircles.Length; ++j)
-            circleSD[j] = new AOEShapeCircle(circleRadius).Distance(avoidCircles[j], default);
+            circleFields[j] = new AOEShapeCircle(circleRadius).Distance(avoidCircles[j], default);
 
         const float circleCushion = 0.25f; // just outside the others' AOEs so the jumps don't clip them
-        const float meleeReach = 3f;        // may edge out to max melee = hitbox + 3 if the boss edge is blocked
+        const float meleeReach = 3f; // may edge out to max melee = hitbox + 3 if the boss edge is blocked
         const float maxSweep = 80f;
         const float stepDeg = 8f;
 
@@ -1107,7 +1108,7 @@ sealed class Replication1Guidance : BossComponent
                 for (var s = -1; s <= 1; s += 2)
                 {
                     var cand = boss.Position + radius * (baseAngle + (s * off).Degrees()).ToDirection();
-                    if (circleSD.Length == 0 || ConeClear(circleSD, cand, circleCushion))
+                    if (circleFields.Length == 0 || IsClearOf(circleFields, cand, circleCushion))
                         return cand;
                     if (off == 0f)
                         break;
@@ -1116,10 +1117,13 @@ sealed class Replication1Guidance : BossComponent
         return boss.Position + boss.HitboxRadius * baseDir; // fallback: on the boss edge, on the side
     }
 
-    static bool ConeClear(ShapeDistance[] sd, WPos p, float cushion)
+    // True when 'point' stays at least 'cushion' units outside every shape in 'fields' (cones and/or circles),
+    // i.e. it's clear of all those hazards with that safety margin. False if it's inside, or within the
+    // cushion of, any of them.
+    static bool IsClearOf(ShapeDistance[] fields, WPos point, float cushion)
     {
-        for (var i = 0; i < sd.Length; ++i)
-            if (sd[i].Distance(p) < cushion)
+        for (var i = 0; i < fields.Length; ++i)
+            if (fields[i].Distance(point) < cushion)
                 return false;
         return true;
     }

--- a/BossMod/Modules/Dawntrail/Savage/M12SP2Lindwurm/Replication1.cs
+++ b/BossMod/Modules/Dawntrail/Savage/M12SP2Lindwurm/Replication1.cs
@@ -1030,12 +1030,12 @@ sealed class Replication1Guidance : BossComponent
         WDir roleBasedPosition = (assign, isDark) switch
         {
             // Dark baits — ranged/healers share the behind-left cardinal waymark
-            (PartyRolesConfig.Assignment.H1, true) or (PartyRolesConfig.Assignment.R1, true) or
-            (PartyRolesConfig.Assignment.H2, true) or (PartyRolesConfig.Assignment.R2, true) => StaticRangedDark,
+            (PartyRolesConfig.Assignment.H1, false) or (PartyRolesConfig.Assignment.R1, false) or
+            (PartyRolesConfig.Assignment.H2, false) or (PartyRolesConfig.Assignment.R2, false) => StaticRangedDark,
 
             // Fire ranged/healer flanks
-            (PartyRolesConfig.Assignment.H1, false) or (PartyRolesConfig.Assignment.R1, false) => StaticH1R1Fire,
-            (PartyRolesConfig.Assignment.H2, false) or (PartyRolesConfig.Assignment.R2, false) => StaticH2R2Fire,
+            (PartyRolesConfig.Assignment.H1, true) or (PartyRolesConfig.Assignment.R1, true) => StaticH1R1Fire,
+            (PartyRolesConfig.Assignment.H2, true) or (PartyRolesConfig.Assignment.R2, true) => StaticH2R2Fire,
 
             // Melee/tank baiting fire (dark debuff): stack both together on the center box's north line
             (PartyRolesConfig.Assignment.MT, false) or (PartyRolesConfig.Assignment.M1, false) or
@@ -1044,47 +1044,9 @@ sealed class Replication1Guidance : BossComponent
             _ => default
         };
 
-        var spot = Center + roleBasedPosition.X * east + roleBasedPosition.Z * north;
-        return AvoidCones(spot, slot, actor);
-    }
-
-    // Builds a signed-distance field per currently-active fire clone cone (WingedScourgeSecond), so a point
-    // can be cheaply tested against all of them. Each field returns negative inside its cone, positive outside.
-    // Returns an empty array when no cones are active.
-    ShapeDistance[] FireCloneConeFields(int slot, Actor actor)
-    {
-        var ws = Module.FindComponent<WingedScourgeSecond>();
-        var cones = ws != null ? ws.ActiveAOEs(slot, actor) : default;
-
-        var fields = new ShapeDistance[cones.Length];
-        for (var i = 0; i < cones.Length; ++i)
-            fields[i] = cones[i].Shape.Distance(cones[i].Origin, cones[i].Rotation);
-        return fields;
-    }
-
-    // Nudge a static safe spot out of the active cones, keeping it as close to the marker as possible.
-    WPos AvoidCones(WPos spot, int slot, Actor actor)
-    {
-        var coneFields = FireCloneConeFields(slot, actor);
-        if (coneFields.Length == 0)
-            return spot;
-
-        const float cushion = 2f;   // stay clearly outside the cone
-        if (IsClearOf(coneFields, spot, cushion))
-            return spot;
-
-        // Nearest-safe search: smallest displacement that clears every cone.
-        const float maxNudge = 10f;
-        const int dirs = 24;
-        for (var r = 0.5f; r <= maxNudge; r += 0.5f)
-            for (var d = 0; d < dirs; ++d)
-            {
-                var cand = spot + r * (d * (360f / dirs)).Degrees().ToDirection();
-                if (IsClearOf(coneFields, cand, cushion))
-                    return cand;
-            }
-
-        return spot; // no safe spot within range — leave it on the marker
+        // Ranged/healers stand EXACTLY on their cardinal waymark (A/C/D rotated to new north) — never nudged
+        // off it for cones: the player body doesn't trigger the cone, only their AoE circle would.
+        return Center + roleBasedPosition.X * east + roleBasedPosition.Z * north;
     }
 
     // The melee's spot: ON the boss (hitbox edge) on the correct side — tight uptime, just outside the central stack.

--- a/BossMod/Modules/Dawntrail/Savage/M12SP2Lindwurm/Replication1.cs
+++ b/BossMod/Modules/Dawntrail/Savage/M12SP2Lindwurm/Replication1.cs
@@ -599,6 +599,8 @@ sealed class Replication1Guidance : BossComponent
     const float PairOffset = 2.25f;
     const float FireCenterOffset = 1.5f;
     const float NearDarkOffset = 1.0f;
+    // Spread-marker radius (matches UniformStackSpread(module, 5, 5) used by the bait components).
+    const float StaticSpreadRadius = 5f;
 
     readonly Replication1SecondBait _bait;
     readonly PartyRolesConfig _prc = Service.Config.Get<PartyRolesConfig>();
@@ -659,6 +661,16 @@ sealed class Replication1Guidance : BossComponent
 
     WPos InitialPosition(PartyRolesConfig.Assignment a)
     {
+        if (_rep1.IsStatic)
+            return StaticInitialPosition(a);
+        else
+        {
+            return CloneRelativeOrDNInitialPosition(a);
+        }
+    }
+
+    WPos CloneRelativeOrDNInitialPosition(PartyRolesConfig.Assignment a)
+    {
         var quadrant = a switch
         {
             PartyRolesConfig.Assignment.H1 or PartyRolesConfig.Assignment.R1 => 0,
@@ -693,6 +705,34 @@ sealed class Replication1Guidance : BossComponent
         };
 
         return anchor + sign * PairOffset * perp;
+    }
+
+    // Static preposition, expressed with angles like CloneRelativeOrDNInitialPosition.
+    // Fire stacks group up:  Melee M1/M2 share an SE point, Tanks MT/OT share an NW point (single shared point each).
+    // Dark spreads fan out:  Ranged R1/R2 around NE, Healers H1/H2 around SW, pushed out to the edge of
+    //                        their spread marker (InitialRadius + StaticSpreadRadius) and split by PairOffset.
+    WPos StaticInitialPosition(PartyRolesConfig.Assignment a)
+    {
+        var edgeRadius = InitialRadius + StaticSpreadRadius; // 12.5
+
+        var (angleDeg, radius, splitSign) = a switch
+        {
+            PartyRolesConfig.Assignment.M1 or PartyRolesConfig.Assignment.M2 => (45f, InitialRadius, 0f),    // SE stack
+            PartyRolesConfig.Assignment.MT or PartyRolesConfig.Assignment.OT => (-135f, InitialRadius, 0f),  // NW stack
+            PartyRolesConfig.Assignment.R1 => (135f, edgeRadius, +1f),                                       // NE
+            PartyRolesConfig.Assignment.R2 => (135f, edgeRadius, -1f),
+            PartyRolesConfig.Assignment.H1 => (-45f, edgeRadius, -1f),                                       // SW
+            PartyRolesConfig.Assignment.H2 => (-45f, edgeRadius, +1f),
+            _ => (0f, InitialRadius, 0f)
+        };
+
+        var dir = angleDeg.Degrees().ToDirection();
+        var anchor = Center + radius * dir;
+        if (splitSign == 0f)
+            return anchor;
+
+        var perp = new WDir(-dir.Z, dir.X);
+        return anchor + splitSign * PairOffset * perp;
     }
 
     // ------------------------------------------------------------
@@ -835,14 +875,8 @@ sealed class Replication1Guidance : BossComponent
                              out var nearDark, out var farDark))
             return null;
 
-        if (_rep1.IsStatic)
-        {
-            return StaticFinalPosition(slot, actor, farDark);
-        }
-        else
-        {
-            return CloneRelativeOrDNFinalPosition(slot, actor, nearFire, farFire, nearDark, farDark);
-        }
+        return _rep1.IsStatic ? StaticFinalPosition(slot, actor, farDark)
+                              : CloneRelativeOrDNFinalPosition(slot, actor, nearFire, farFire, nearDark, farDark);
     }
 
     WPos? CloneRelativeOrDNFinalPosition(int slot, Actor actor, WPos nearFire, WPos farFire, WPos nearDark, WPos farDark)
@@ -927,31 +961,27 @@ sealed class Replication1Guidance : BossComponent
     // STATIC STRATEGY
     // ------------------------------------------------------------
     //
-    // The dark clone closest to the wall (= farDark) defines a "new North".
+    // The dark clone closest to the wall (farDark) defines a "new North".
     // All 8 safe spots are expressed as offsets in that rotated local frame,
-    // where +Z = toward farDark (new North) and +X = 90° clockwise (new East).
+    // where +Z = relative-North (toward farDark) and +X = relative-East (90° clockwise).
     //
-    // 3 spots reuse the existing Outer[] radius (distance 14 from center):
-    //   - H2/R2 dark  → relative-N outer
-    //   - H1/R1 dark  → relative-W outer
-    //   - H1/R1 + H2/R2 fire → SW outer corner (stacked)
+    // Ranged/healer:
+    //   - Dark (H1/R1 & H2/R2)  → behind-left cardinal waymark (rel-SW). new north @4 → C, @1 → D, ...
+    //   - Fire H1/R1            → left  flank cardinal waymark (rel-NW). new north @4 → D
+    //   - Fire H2/R2            → right flank cardinal waymark (rel-NE). new north @4 → A
     //
-    // The remaining 4 inner spots are hand-tuned constants and may need
-    // in-game adjustment against the reference image.
-    //
+    // Melee/tank:
+    //   - Fire debuff (baits dark) → on the boss's edge in melee range, split MT/M1 left (rel-West),
+    //                                OT/M2 right (rel-East), away from the stacked fire-baiters.
+    //   - Dark debuff (baits fire) → stack both together on the center box's north line.
 
-    const float StaticOuterRadius = 14f; // same magnitude as Outer[] markers
+    const float StaticWaymarkRadius = 13.65f;      // A/B/C/D cardinal waymark distance from center
 
-    // Offsets in the new-north frame (X = new-east, Z = new-north).
-    static readonly WDir StaticH1R1Dark = new(-StaticOuterRadius, 0);                 // rel-W outer
-    static readonly WDir StaticH2R2Dark = new(0, StaticOuterRadius);                  // rel-N outer
-    static readonly WDir StaticRangedFire = new(-StaticOuterRadius * 0.5f, -StaticOuterRadius * 0.5f); // rel-SW outer (H1/R1 + H2/R2 stacked)
-
-    // Hand-tuned inner spots.
-    static readonly WDir StaticMTM1Fire = new(0, 1.5f);    // center, on northern line of center box
-    static readonly WDir StaticOTM2Fire = new(3f, 1.5f);   // east of center, on northern line
-    static readonly WDir StaticMTM1Dark = new(-3f, 3f);    // rel-NW inner, one box below new-north white line
-    static readonly WDir StaticOTM2Dark = new(3f, 3f);     // rel-NE inner, one box below new-north white line
+    // Offsets in the new-north frame (X = rel-East, Z = rel-North).
+    static readonly WDir StaticH2R2Fire = StaticWaymarkRadius * new WDir(1f, 1f).Normalized(); // rel-NE flank (right) = A@4
+    static readonly WDir StaticH1R1Fire = StaticWaymarkRadius * new WDir(-1f, 1f).Normalized(); // rel-NW flank (left)  = D@4
+    static readonly WDir StaticRangedDark = StaticWaymarkRadius * new WDir(-1f, -1f).Normalized(); // rel-SW behind-left  = C@4
+    static readonly WDir StaticMeleeFire = new(0f, 1.5f); // baits fire: stack on the center box's north line
 
     bool BuildNewNorthBasis(WPos farDark, out WDir north, out WDir east)
     {
@@ -968,40 +998,130 @@ sealed class Replication1Guidance : BossComponent
         return true;
     }
 
+    static bool IsMeleeOrTank(PartyRolesConfig.Assignment a)
+        => a is PartyRolesConfig.Assignment.MT or PartyRolesConfig.Assignment.OT
+              or PartyRolesConfig.Assignment.M1 or PartyRolesConfig.Assignment.M2;
+
     WPos? StaticFinalPosition(int slot, Actor actor, WPos farDark)
     {
         if (!BuildNewNorthBasis(farDark, out var north, out var east))
             return null;
 
         var assign = _assignments[slot];
-        var mech = BaitType(actor);
 
-        WDir local = (assign, mech) switch
+        // Baits dark ⇔ does NOT have Dark Resistance Down (i.e. has Fire Resistance Down, or none yet).
+        // Use BaitType so this matches the shared logic and doesn't depend on positively reading the
+        // fire debuff — relying on the dark debuff's absence is robust to timing/detection gaps.
+        var isDark = BaitType(actor) == Replication1SecondBait.Assignment.Dark;
+
+        // Melee/tank with the FIRE debuff (baits dark): stand on the boss's edge in melee range,
+        // split MT/M1 left (rel-West), OT/M2 right (rel-East), away from the stacked fire-baiters.
+        if (isDark && IsMeleeOrTank(assign))
         {
-            // Dark baits
-            (PartyRolesConfig.Assignment.H1, Replication1SecondBait.Assignment.Dark) => StaticH1R1Dark,
-            (PartyRolesConfig.Assignment.R1, Replication1SecondBait.Assignment.Dark) => StaticH1R1Dark,
-            (PartyRolesConfig.Assignment.H2, Replication1SecondBait.Assignment.Dark) => StaticH2R2Dark,
-            (PartyRolesConfig.Assignment.R2, Replication1SecondBait.Assignment.Dark) => StaticH2R2Dark,
-            (PartyRolesConfig.Assignment.MT, Replication1SecondBait.Assignment.Dark) => StaticMTM1Dark,
-            (PartyRolesConfig.Assignment.M1, Replication1SecondBait.Assignment.Dark) => StaticMTM1Dark,
-            (PartyRolesConfig.Assignment.OT, Replication1SecondBait.Assignment.Dark) => StaticOTM2Dark,
-            (PartyRolesConfig.Assignment.M2, Replication1SecondBait.Assignment.Dark) => StaticOTM2Dark,
+            var boss = Module.PrimaryActor;
+            var side = assign is PartyRolesConfig.Assignment.MT or PartyRolesConfig.Assignment.M1 ? -1f : 1f;
+            // On the boss on the correct side (MT/M1 left, OT/M2 right), keeping the bait/jump clear of the other
+            // players' circles: the dark-melee stack (north), the other side melee, and the ranged waymark spots.
+            WPos ToWorld(WDir o) => Center + o.X * east + o.Z * north;
+            var otherMelee = boss.Position + boss.HitboxRadius * (-side) * east;
+            Span<WPos> circles = [ToWorld(StaticMeleeFire), otherMelee, ToWorld(StaticRangedDark), ToWorld(StaticH1R1Fire), ToWorld(StaticH2R2Fire)];
+            return MeleeEdgeSpot(slot, actor, side * east, boss, circles, StaticSpreadRadius);
+        }
 
-            // Fire baits
-            (PartyRolesConfig.Assignment.MT, Replication1SecondBait.Assignment.Fire) => StaticMTM1Fire,
-            (PartyRolesConfig.Assignment.M1, Replication1SecondBait.Assignment.Fire) => StaticMTM1Fire,
-            (PartyRolesConfig.Assignment.OT, Replication1SecondBait.Assignment.Fire) => StaticOTM2Fire,
-            (PartyRolesConfig.Assignment.M2, Replication1SecondBait.Assignment.Fire) => StaticOTM2Fire,
-            (PartyRolesConfig.Assignment.H1, Replication1SecondBait.Assignment.Fire) => StaticRangedFire,
-            (PartyRolesConfig.Assignment.R1, Replication1SecondBait.Assignment.Fire) => StaticRangedFire,
-            (PartyRolesConfig.Assignment.H2, Replication1SecondBait.Assignment.Fire) => StaticRangedFire,
-            (PartyRolesConfig.Assignment.R2, Replication1SecondBait.Assignment.Fire) => StaticRangedFire,
+        WDir local = (assign, isDark) switch
+        {
+            // Dark baits — ranged/healers share the behind-left cardinal waymark
+            (PartyRolesConfig.Assignment.H1, true) or (PartyRolesConfig.Assignment.R1, true) or
+            (PartyRolesConfig.Assignment.H2, true) or (PartyRolesConfig.Assignment.R2, true) => StaticRangedDark,
+
+            // Fire ranged/healer flanks
+            (PartyRolesConfig.Assignment.H1, false) or (PartyRolesConfig.Assignment.R1, false) => StaticH1R1Fire,
+            (PartyRolesConfig.Assignment.H2, false) or (PartyRolesConfig.Assignment.R2, false) => StaticH2R2Fire,
+
+            // Melee/tank baiting fire (dark debuff): stack both together on the center box's north line
+            (PartyRolesConfig.Assignment.MT, false) or (PartyRolesConfig.Assignment.M1, false) or
+            (PartyRolesConfig.Assignment.OT, false) or (PartyRolesConfig.Assignment.M2, false) => StaticMeleeFire,
 
             _ => default
         };
 
-        return Center + local.X * east + local.Z * north;
+        var spot = Center + local.X * east + local.Z * north;
+        return AvoidCones(spot, slot, actor);
+    }
+
+    // Signed-distance fields for the active red-clone cones (WingedScourgeSecond). Negative = inside a cone.
+    ShapeDistance[] ConeHazards(int slot, Actor actor)
+    {
+        var ws = Module.FindComponent<WingedScourgeSecond>();
+        var cones = ws != null ? ws.ActiveAOEs(slot, actor) : default;
+
+        var sd = new ShapeDistance[cones.Length];
+        for (var i = 0; i < cones.Length; ++i)
+            sd[i] = cones[i].Shape.Distance(cones[i].Origin, cones[i].Rotation);
+        return sd;
+    }
+
+    // Nudge a static safe spot out of the active cones, keeping it as close to the marker as possible.
+    WPos AvoidCones(WPos spot, int slot, Actor actor)
+    {
+        var sd = ConeHazards(slot, actor);
+        if (sd.Length == 0)
+            return spot;
+
+        const float cushion = 2f;   // stay clearly outside the shape
+        if (ConeClear(sd, spot, cushion))
+            return spot;
+
+        // Nearest-safe search: smallest displacement that clears every hazard.
+        const float maxNudge = 10f;
+        const int dirs = 24;
+        for (var r = 0.5f; r <= maxNudge; r += 0.5f)
+            for (var d = 0; d < dirs; ++d)
+            {
+                var cand = spot + r * (d * (360f / dirs)).Degrees().ToDirection();
+                if (ConeClear(sd, cand, cushion))
+                    return cand;
+            }
+
+        return spot; // no safe spot within range — leave it on the marker
+    }
+
+    // The melee's spot: ON the boss (hitbox edge) on the correct side — tight uptime, just outside the central
+    // stack. It edges outward only as far as max melee if the close ring is blocked, sweeping around the boss so
+    // its bait/jump stays clear of the other players' circles. Cones are NOT dodged (one cone may clip by design).
+    WPos MeleeEdgeSpot(int slot, Actor actor, WDir baseDir, Actor boss, ReadOnlySpan<WPos> avoidCircles, float circleRadius)
+    {
+        var baseAngle = baseDir.ToAngle();
+        var circleSD = new ShapeDistance[avoidCircles.Length];
+        for (var j = 0; j < avoidCircles.Length; ++j)
+            circleSD[j] = new AOEShapeCircle(circleRadius).Distance(avoidCircles[j], default);
+
+        const float circleCushion = 0.25f; // just outside the others' AOEs so the jumps don't clip them
+        const float meleeReach = 3f;        // may edge out to max melee = hitbox + 3 if the boss edge is blocked
+        const float maxSweep = 80f;
+        const float stepDeg = 8f;
+
+        // Prefer the closest ring (boss edge), sweeping the angle; edge outward only if nothing there is clear.
+        for (var radius = boss.HitboxRadius; radius <= boss.HitboxRadius + meleeReach + 0.01f; radius += 1f)
+            for (var off = 0f; off <= maxSweep; off += stepDeg)
+                for (var s = -1; s <= 1; s += 2)
+                {
+                    var cand = boss.Position + radius * (baseAngle + (s * off).Degrees()).ToDirection();
+                    if (circleSD.Length == 0 || ConeClear(circleSD, cand, circleCushion))
+                        return cand;
+                    if (off == 0f)
+                        break;
+                }
+
+        return boss.Position + boss.HitboxRadius * baseDir; // fallback: on the boss edge, on the side
+    }
+
+    static bool ConeClear(ShapeDistance[] sd, WPos p, float cushion)
+    {
+        for (var i = 0; i < sd.Length; ++i)
+            if (sd[i].Distance(p) < cushion)
+                return false;
+        return true;
     }
 
     // ------------------------------------------------------------
@@ -1015,7 +1135,7 @@ sealed class Replication1Guidance : BossComponent
 
         // Mark the wall-dark clone as "new North" for Static strategy.
         if (_rep1.IsStatic && TryGetFormation(out _, out _, out _, out var farDark))
-            Arena.AddCircle(farDark, 1.25f, Colors.Object);
+            Arena.AddCircle(farDark, 1.25f, Colors.Other1);
 
         var pos = DebuffsAssigned()
             ? FinalPosition(pcSlot, pc)

--- a/BossModReborn.sln
+++ b/BossModReborn.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.5.11723.231
+VisualStudioVersion = 18.5.11723.231 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BossModReborn", "BossMod\BossModReborn.csproj", "{13C812E9-0D42-4B95-8646-40EEBF30636F}"
 EndProject

--- a/BossModReborn.sln
+++ b/BossModReborn.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.5.11723.231 stable
+VisualStudioVersion = 18.5.11723.231
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BossModReborn", "BossMod\BossModReborn.csproj", "{13C812E9-0D42-4B95-8646-40EEBF30636F}"
 EndProject


### PR DESCRIPTION
Added the Replication 1 static logic for EU party finder.
You can find the raid plan and the images regarding the strategy in: https://wtfdig.info/74/m12s#caro::static::caroUptime
Also modified Replication1Guidance to a more form fitting name as it now contains all 3 strategies inside of it.