### PR TITLE
Drowned city of skalla

### DIFF
--- a/BossMod/Modules/Stormblood/Dungeon/D09DrownedCityOfSkalla/D091Kelpie.cs
+++ b/BossMod/Modules/Stormblood/Dungeon/D09DrownedCityOfSkalla/D091Kelpie.cs
@@ -1,0 +1,202 @@
+namespace BossMod.Stormblood.Dungeon.D09DrownedCityOfSkalla.D091Kelpie;
+
+public enum OID : uint
+{
+    Kelpie = 0x1FAB, // R5.400, x?
+    Kelpie1 = 0x18D6, // R0.500, x?, Helper type
+    Hydrosphere = 0x2051, // R1.200, x?, Helper type
+    WaterPuddles = 0x1EA7D5, // R0.500, x?, EventObj type
+}
+
+public enum AID : uint
+{
+    AutoAttack = 872, // 1FAB->player, no cast, single-target
+    Torpedo = 9807, // 1FAB->player, 2.0s cast, single-target
+    RisingSeas = 9808, // 1FAB->self, 3.0s cast, range 50+R circle
+    Gallop = 9811, // 1FAB->location, no cast, ???
+    HydroPull = 9809, // 1FAB->self, 7.0s cast, ??? : Draw in
+    HydroPush = 9810, // 1FAB->self, 7.0s cast, range 50+R circle : Knockback
+    BloodyPuddle = 9812, // 1FAB->self, 5.0s cast, single-target
+    BloodyPuddle1 = 9813, // 18D6->self, no cast, range 8 circle
+    BubbleBurst = 9755, // 2051->self, 1.0s cast, range 6 circle
+}
+
+public enum IconID : uint
+{
+    BloodyPuddleBaitIcon = 43, // player/3F75/40C0->self
+    BloodyPuddleTetherIcon = 1, // player/3F75/40C0->self
+}
+
+public enum TetherID : uint
+{
+    HydrosphereTether = 3, // Hydrosphere->player/3F75/40C0
+}
+
+
+sealed class RisingSeas(BossModule module) : Components.RaidwideCast(module, (uint)AID.RisingSeas);
+
+sealed class HydroPull(BossModule module) : Components.SimpleKnockbacks(module, (uint)AID.HydroPull, 20f, kind: Kind.DirBackward)
+{
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        if (Casters.Count != 0)
+        {
+            ref readonly var kb = ref Casters.Ref(0);
+            var act = kb.Activation;
+            if (!IsImmune(slot, act))
+            {
+                hints.AddForbiddenZone(new SDRect(kb.Origin, kb.Direction, 32f, 32f, 14.5f));
+            }
+        }
+        base.AddAIHints(slot, actor, assignment, hints);
+    }
+}
+
+sealed class HydroPush(BossModule module) : Components.SimpleKnockbacks(module, (uint)AID.HydroPush, 20f, kind: Kind.DirForward)
+{
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        if (Casters.Count != 0)
+        {
+            ref readonly var kb = ref Casters.Ref(0);
+            var act = kb.Activation;
+            if (!IsImmune(slot, act))
+            {
+                // We avoid the corners in case a puddle was placed there.
+                hints.AddForbiddenZone(new SDInvertedRect(kb.Origin, kb.Direction, 10f, 10f, 11f));
+            }
+        }
+        base.AddAIHints(slot, actor, assignment, hints);
+    }
+}
+
+sealed class BloodyPuddle(BossModule module) : Components.BaitAwayIcon(module, new AOEShapeCircle(4f),
+    (uint)IconID.BloodyPuddleBaitIcon, (uint)AID.BloodyPuddle1, 0f, true)
+{
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        var _activation = WorldState.FutureTime(5.0f);
+        // We want to path to the corner if we have a puddle bait.
+        WPos[] corners = [new (-207f, -9f), new (-233f, -9f), new (-233f, 17f), new (-207f, 17f)];
+        var count = corners.Length;
+        if (count != 0 && ActiveBaits.Count > 0)
+        {
+            var baitZonez = new ShapeDistance[count];
+            for (var i = 0; i < count; ++i)
+            {
+                var c = corners[i];
+                // purposefully smaller than the puddle.
+                baitZonez[i] = new SDInvertedCircle(c, 1.5f);
+            }
+            hints.AddForbiddenZone(new SDIntersection(baitZonez), _activation);
+        }
+        base.AddAIHints(slot, actor, assignment, hints);
+    }
+}
+
+/*
+ * Puddles that stay on the arena for several minutes.
+ */
+sealed class WaterPuddles(BossModule module) : BossComponent(module)
+{
+    public static List<Actor> GetPuddles(BossModule module)
+    {
+        var orbs = module.Enemies((uint)OID.WaterPuddles);
+        var count = orbs.Count;
+        if (count == 0)
+            return [];
+
+        var filteredWater = new List<Actor>(count);
+        for (var i = 0; i < count; ++i)
+        {
+            var z = orbs[i];
+            if (!z.IsDead)
+                filteredWater.Add(z);
+        }
+        return filteredWater;
+    }
+
+    public override void AddGlobalHints(GlobalHints hints)
+    {
+        var orbs = GetPuddles(Module);
+        var count = orbs.Count;
+        if (count != 0)
+            hints.Add("Avoid puddles.");
+    }
+
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        var puddles = GetPuddles(Module);
+        var count = puddles.Count;
+
+        if (count != 0)
+        {
+            var puddlez = new ShapeDistance[count];
+            for (var i = 0; i < count; ++i)
+            {
+                var p = puddles[i];
+                puddlez[i] = new SDCircle(p.Position, 8f);
+            }
+            hints.AddForbiddenZone(new SDUnion(puddlez));
+        }
+        base.AddAIHints(slot, actor, assignment, hints);
+    }
+
+    public override void DrawArenaForeground(int pcSlot, Actor pc)
+    {
+        var orbs = GetPuddles(Module);
+        var count = orbs.Count;
+        for (var i = 0; i < count; ++i)
+        {
+            // TODO would be nice if these only draw the portion inside arena bounds.
+            Arena.AddCircleFilled(orbs[i].Position, 7f, Colors.Danger);
+        }
+    }
+}
+
+// Show the tether object
+class BloodyBurstTether(BossModule module) : Components.BaitAwayTethers(module, new AOEShapeCircle(6f), (uint)TetherID.HydrosphereTether, (uint)AID.BubbleBurst, enemyOID: (uint)OID.Hydrosphere);
+
+
+[SkipLocalsInit]
+sealed class KelpieStates : StateMachineBuilder
+{
+    public KelpieStates(BossModule module) : base(module)
+    {
+        DeathPhase(default, SinglePhase);
+    }
+
+    private void SinglePhase(uint id)
+    {
+        SimpleState(id + 0xFF0000u, 10000f, "???")
+            .ActivateOnEnter<RisingSeas>()
+            .ActivateOnEnter<HydroPull>()
+            .ActivateOnEnter<HydroPush>()
+            .ActivateOnEnter<WaterPuddles>()
+            .ActivateOnEnter<BloodyPuddle>()
+            .ActivateOnEnter<BloodyBurstTether>()
+            ;
+    }
+}
+
+
+[ModuleInfo(BossModuleInfo.Maturity.WIP,
+    StatesType = typeof(KelpieStates),
+    ConfigType = null, // replace null with typeof(KelpieConfig) if applicable
+    ObjectIDType = typeof(OID),
+    ActionIDType = typeof(AID),
+    StatusIDType = null, // replace null with typeof(SID) if applicable
+    TetherIDType = typeof(TetherID),
+    IconIDType = typeof(IconID),
+    PrimaryActorOID = (uint)OID.Kelpie,
+    Contributors = "wen",
+    Expansion = BossModuleInfo.Expansion.Stormblood,
+    Category = BossModuleInfo.Category.Dungeon,
+    GroupType = BossModuleInfo.GroupType.CFC,
+    GroupID = 279u,
+    NameID = 6907u,
+    SortOrder = 1,
+    PlanLevel = 0)]
+[SkipLocalsInit]
+
+public sealed class Kelpie(WorldState ws, Actor primary) : BossModule(ws, primary, new(-220f, 4f), new ArenaBoundsSquare(14.5f));

--- a/BossMod/Modules/Stormblood/Dungeon/D09DrownedCityOfSkalla/D092OldOne.cs
+++ b/BossMod/Modules/Stormblood/Dungeon/D09DrownedCityOfSkalla/D092OldOne.cs
@@ -1,0 +1,129 @@
+namespace BossMod.Stormblood.Dungeon.D09DrownedCityOfSkalla.D092OldOne;
+
+public enum OID : uint
+{
+    Helper = 0x18D6, // R0.500, x?, Helper type
+    TheOldOne = 0x1FAC, // R4.600, x?
+    Subservient = 0x1FAD, // R1.725, x?
+}
+
+public enum AID : uint
+{
+    _AutoAttack_ = 29791, // TheOldOne->player, no cast, single-target
+    MysticLight = 9815, // TheOldOne->self, 4.0s cast, range 40+R 60.000-degree cone
+    MysticFlame = 9816, // TheOldOne->self, 3.0s cast, single-target
+    MysticFlame1 = 9817, // Helper->self, 3.5s cast, range 8 circle
+    ShiftingLight = 9818, // TheOldOne->self, 3.0s cast, range 20+R circle
+    Shatterstone = 9824, // Helper->self, 2.0s cast, range 5 circle : Duty action : This is not the duty action.
+    OrderToDetonate = 9819, // TheOldOne->self, 20.0s cast, single-target
+}
+
+public enum SID : uint
+{
+    Invincibility = 325, // none->Helper/TheOldOne/_Gen_, extra=0x0 : Boss goes invincible while subservient are out.
+    Transfiguration = 1448, // none->player/3F7F/40C0/3F75, extra=0x4A : players transformed.
+}
+
+
+sealed class MysticLight(BossModule module)
+    : Components.SimpleAOEs(module, (uint)AID.MysticLight, new AOEShapeCone(40f, 30f.Degrees()));
+
+sealed class MysticFlame(BossModule module) : Components.SimpleAOEs(module, (uint)AID.MysticFlame1, new AOEShapeCircle(8f));
+
+sealed class SubservientAdds(BossModule module) : Components.Adds(module, (uint)OID.Subservient, priority: 1);
+
+sealed class ShiftingLight(BossModule module) : Components.RaidwideCast(module, (uint)AID.ShiftingLight);
+
+// pc gets turned into a sprite.  When that happens go kill the subservients with shatterstone duty action.
+sealed class Shatterstone(BossModule module) : BossComponent(module)
+{
+    // store whether or not we have the transfiguration status
+    private BitMask _transfigurationStatus;
+
+    public override void OnStatusGain(Actor actor, ref ActorStatus status)
+    {
+        if (status.ID == (uint)SID.Transfiguration && Raid.FindSlot(actor.InstanceID) is var slot && slot >= 0)
+        {
+            _transfigurationStatus[slot] = true;
+        }
+    }
+
+    public override void OnStatusLose(Actor actor, ref ActorStatus status)
+    {
+        if (Raid.FindSlot(actor.InstanceID) is var slot && slot >= 0)
+        {
+            if (status.ID == (uint)SID.Transfiguration)
+                _transfigurationStatus[slot] = false;
+        }
+    }
+
+    public IEnumerable<Actor> Subservients => Module.Enemies((uint)OID.Subservient).Where(x => !x.IsDeadOrDestroyed);
+
+    public override void DrawArenaForeground(int pcSlot, Actor pc)
+    {
+        Arena.Actors(Subservients, Colors.Enemy);
+    }
+
+    // Move toward the nearest Subservient add. If transfigure then use the dutyaction to  attack.
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        base.AddAIHints(slot, actor, assignment, hints);
+        var attackRadius = 4;
+
+        var closestSub = Subservients.MaxBy(x => x.PosRot.Z);
+        if (closestSub != null)
+        {
+            var pos = closestSub.Position;
+            WPos optimalAttackPosition = new(pos.X, pos.Z + 1);
+            // move towards nearest subservient add.
+            hints.GoalZones.Add(AIHints.GoalSingleTarget(optimalAttackPosition, attackRadius - 2, 10));
+            // use duty action if you are transformed.
+            if (actor.DistanceToHitbox(closestSub) < attackRadius - 1  && _transfigurationStatus[slot])
+                hints.ActionsToExecute.Push(ActionID.MakeSpell(ClassShared.AID.Shatterstone), null, ActionQueue.Priority.High, targetPos: closestSub.PosRot.XYZ());
+        }
+    }
+}
+
+sealed class OrderToDetonate(BossModule module) : Components.RaidwideCast(module, (uint)AID.OrderToDetonate);
+
+[SkipLocalsInit]
+sealed class TheOldOneStates : StateMachineBuilder
+{
+    public TheOldOneStates(BossModule module) : base(module)
+    {
+        DeathPhase(default, SinglePhase);
+    }
+
+    private void SinglePhase(uint id)
+    {
+        SimpleState(id + 0xFF0000u, 10000f, "???")
+            .ActivateOnEnter<MysticLight>()
+            .ActivateOnEnter<MysticFlame>()
+            .ActivateOnEnter<SubservientAdds>()
+            .ActivateOnEnter<ShiftingLight>()
+            .ActivateOnEnter<Shatterstone>()
+            .ActivateOnEnter<OrderToDetonate>()
+            ;
+    }
+}
+
+[ModuleInfo(BossModuleInfo.Maturity.WIP,
+    StatesType = typeof(TheOldOneStates),
+    ConfigType = null, // replace null with typeof(TheOldOneConfig) if applicable
+    ObjectIDType = typeof(OID),
+    ActionIDType = typeof(AID),
+    StatusIDType = typeof(SID),
+    TetherIDType = null, // replace null with typeof(TetherID) if applicable
+    IconIDType = null, // replace null with typeof(IconID) if applicable
+    PrimaryActorOID = (uint)OID.TheOldOne,
+    Contributors = "wen",
+    Expansion = BossModuleInfo.Expansion.Stormblood,
+    Category = BossModuleInfo.Category.Dungeon,
+    GroupType = BossModuleInfo.GroupType.CFC,
+    GroupID = 279u,
+    NameID = 6908u,
+    SortOrder = 1,
+    PlanLevel = 0)]
+
+[SkipLocalsInit]
+public sealed class TheOldOne(WorldState ws, Actor primary) : BossModule(ws, primary, new(115f, 4f), new ArenaBoundsCircle(20f));

--- a/BossMod/Modules/Stormblood/Dungeon/D09DrownedCityOfSkalla/D093HrodricPoisonTongue.cs
+++ b/BossMod/Modules/Stormblood/Dungeon/D09DrownedCityOfSkalla/D093HrodricPoisonTongue.cs
@@ -1,0 +1,142 @@
+namespace BossMod.Stormblood.Dungeon.D09DrownedCityOfSkalla.D093HrodricPoisonTongue;
+
+public enum OID : uint
+{
+    HrodricPoisontongue = 0x1FAE,
+    Helper = 0x18D6, // R0.500, x?
+}
+
+public enum AID : uint
+{
+    AutoAttack = 870, // 1FAE->player, no cast, single-target
+    RustingClaw = 9825, // 1FAE->self, 5.0s cast, range 8+R ?-degree cone
+    TailDrive = 9827, // 1FAE->self, 5.0s cast, range 30+R ?-degree cone
+    TheSpin = 9828, // 1FAE->self, 5.0s cast, range 40+R circle
+    _Weaponskill_ = 9830, // 1FAE->self, no cast, single-target
+    RingOfChaos = 9831, // 18D6->self, no cast, range ?-20 donut
+    EyeOfTheFire = 9829, // 1FAE->self, 3.0s cast, range 40 circle : Gaze Attack
+    CircleOfChaos = 9833, // 18D6->self, no cast, range 6 circle
+    CrossOfChaos = 9832, // 18D6->self, no cast, range 50 width 8 cross
+    WordsOfWoe = 9826, // 1FAE->self, 3.0s cast, range 45+R width 6 rect
+}
+
+public enum IconID : uint
+{
+    RingOfChaosIcon = 121,
+    SpreadCross = 122,
+    SpreadCircle = 28,
+}
+
+// Angle is an estimate. Radius might be less than 17 might be slightly more. It definitely isn't all the way off arena.
+sealed class RustingClaw(BossModule module)
+    : Components.SimpleAOEs(module, (uint)AID.RustingClaw, new AOEShapeCone(17f, 45f.Degrees()));
+//Angle is an estimate
+sealed class TailDrive(BossModule module)
+    : Components.SimpleAOEs(module, (uint)AID.TailDrive, new AOEShapeCone(50f, 40f.Degrees()));
+
+// Spread to outside of arena
+sealed class TheSpin(BossModule module) : Components.ProximityAOEs(module, (uint)AID.TheSpin, 17f);
+
+sealed class EyeOfTheFire(BossModule module) : Components.CastGaze(module, (uint)AID.EyeOfTheFire);
+
+/*
+ * This should cover the various baits that use the SpreadCross/SpreadCircle/Donut icons.
+ * Might make more sense for cross and circle to be spread from icon.
+ */
+sealed class ChaosBaits(BossModule module) : Components.GenericBaitAway(module)
+{
+    public override void OnEventIcon(Actor actor, uint iconID, ulong targetID)
+    {
+        DateTime _nextActivation = WorldState.FutureTime(4.7f);
+        // next target is the pc with the icon.
+        Actor? _nextTarget = WorldState.Actors.Find(targetID);
+
+        if ((IconID)iconID == IconID.SpreadCross && _nextTarget != null)
+        {
+            // 180 degrees rotation to keep the cross from spinning with pc.
+            CurrentBaits.Add(new(_nextTarget, _nextTarget, new AOEShapeCross(40f, 4f), _nextActivation, customRotation: 180.Degrees()));
+        }
+        else if ((IconID)iconID == IconID.SpreadCircle &&  _nextTarget != null)
+        {
+            CurrentBaits.Add(new(_nextTarget, _nextTarget, new AOEShapeCircle(7f), _nextActivation));
+        }
+        else if ((IconID)iconID == IconID.RingOfChaosIcon &&  _nextTarget != null)
+        {
+            CurrentBaits.Add(new(_nextTarget, _nextTarget, new AOEShapeDonut(10f, 20f), _nextActivation));
+        }
+    }
+
+    public override void OnEventCast(Actor caster, ActorCastEvent spell)
+    {
+        if (spell.Action.ID
+            is (uint)AID.CircleOfChaos
+            or (uint)AID.CrossOfChaos)
+        {
+            CurrentBaits.RemoveAll(bait => bait.Shape is AOEShapeCircle or AOEShapeCross);
+        }
+        else if (spell.Action.ID == (uint)AID.RingOfChaos)
+        {
+            CurrentBaits.RemoveAll(bait => bait.Shape is AOEShapeDonut);
+        }
+        NumCasts++;
+    }
+
+    public override void AddAIHints(int slot, Actor actor, PartyRolesConfig.Assignment assignment, AIHints hints)
+    {
+        foreach (var bait in CurrentBaits)
+        {
+            // bait the circle and cross to the edge of arena.
+            if (bait.Source == actor && (bait.Shape is AOEShapeCircle or AOEShapeCross))
+                hints.AddForbiddenZone(new AOEShapeCircle(16f), Arena.Center, default, bait.Activation);
+            // bait the donut to the center.
+            else if (bait.Source == actor && bait.Shape is AOEShapeDonut)
+                hints.AddForbiddenZone(new AOEShapeCircle(6f, true), Arena.Center, default, bait.Activation);
+        }
+        // remember to run base AIHints so it will see the other baits avoidance also.
+        base.AddAIHints(slot, actor, assignment, hints);
+    }
+}
+
+sealed class WordsOfWoe(BossModule module) : Components.SimpleAOEs(module, (uint)AID.WordsOfWoe, new AOEShapeRect(65f, 3f));
+
+
+[SkipLocalsInit]
+sealed class HrodricPoisontongueStates : StateMachineBuilder
+{
+    public HrodricPoisontongueStates(BossModule module) : base(module)
+    {
+        DeathPhase(default, SinglePhase);
+    }
+
+    private void SinglePhase(uint id)
+    {
+        SimpleState(id + 0xFF0000u, 10000f, "???")
+            .ActivateOnEnter<RustingClaw>()
+            .ActivateOnEnter<TailDrive>()
+            .ActivateOnEnter<TheSpin>()
+            .ActivateOnEnter<ChaosBaits>()
+            .ActivateOnEnter<EyeOfTheFire>()
+            .ActivateOnEnter<WordsOfWoe>()
+            ;
+    }
+}
+
+[ModuleInfo(BossModuleInfo.Maturity.Contributed,
+    StatesType = typeof(HrodricPoisontongueStates),
+    ConfigType = null, // replace null with typeof(HrodricPoisontongueConfig) if applicable
+    ObjectIDType = typeof(OID),
+    ActionIDType = typeof(AID),
+    StatusIDType = null, // replace null with typeof(SID) if applicable
+    TetherIDType = null, // replace null with typeof(TetherID) if applicable
+    IconIDType = typeof(IconID),
+    PrimaryActorOID = (uint)OID.HrodricPoisontongue,
+    Contributors = "",
+    Expansion = BossModuleInfo.Expansion.Stormblood,
+    Category = BossModuleInfo.Category.Dungeon,
+    GroupType = BossModuleInfo.GroupType.CFC,
+    GroupID = 279u,
+    NameID = 6910u,
+    SortOrder = 1,
+    PlanLevel = 0)]
+[SkipLocalsInit]
+public sealed class HrodricPoisontongue(WorldState ws, Actor primary) : BossModule(ws, primary, new(479f, 4f), new ArenaBoundsCircle(20f));


### PR DESCRIPTION
Added modules for bosses in drowned city of skalla.

All bosses implemented with aihints.  Knockbacks, duty actions, baits, etc have been given movement hints.  
