### PR TITLE
EX8: Remove AIHint for sprint

### DIFF
--- a/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/GazeOfTheVoid.cs
+++ b/BossMod/Modules/Dawntrail/Extreme/Ex8Enuo/GazeOfTheVoid.cs
@@ -37,7 +37,7 @@ sealed class GazeOfTheVoidSoaks(BossModule module) : BossComponent(module)
             if (count != 0)
             {
                 var orbz = new ShapeDistance[count];
-                hints.ActionsToExecute.Push(ActionDefinitions.IDSprint, actor, ActionQueue.Priority.High);
+                //hints.ActionsToExecute.Push(ActionDefinitions.IDSprint, actor, ActionQueue.Priority.High);
                 for (var i = 0; i < count; ++i)
                 {
                     var o = orbs[i];
@@ -51,7 +51,7 @@ sealed class GazeOfTheVoidSoaks(BossModule module) : BossComponent(module)
             if (bigcount != 0)
             {
                 var orbz = new ShapeDistance[bigcount];
-                hints.ActionsToExecute.Push(ActionDefinitions.IDSprint, actor, ActionQueue.Priority.High);
+                //hints.ActionsToExecute.Push(ActionDefinitions.IDSprint, actor, ActionQueue.Priority.High);
                 for (var i = 0; i < bigcount; ++i)
                 {
                     var o = bigorbs[i];


### PR DESCRIPTION
Removing the AIHint for Sprint since people keep letting BMR execute actions for them.  AI movement for orbs isn't very good anyway, so it's probably superfluous.