### PR TITLE
DMU: Phase 2 fixes & Phase 3 hints for final mechanic

### DIFF
--- a/BossMod/Modules/Dawntrail/Ultimate/DMU/DMUEnums.cs
+++ b/BossMod/Modules/Dawntrail/Ultimate/DMU/DMUEnums.cs
@@ -221,8 +221,8 @@ public enum AID : uint {
 
     UltimaUpsurge = 49738, // KefkaP4->self, 5.0s cast, range 100 circle
 
-    StrayFlamesP4 = 47906, // Helper->location, 5.0s cast, range 6 circle
-    StraySprayP4 = 47909, // Helper->location, 5.0s cast, range 6 circle
+    StrayFlamesP4Puddle = 47906, // Helper->location, 5.0s cast, range 6 circle
+    StraySprayP4Puddle = 47909, // Helper->location, 5.0s cast, range 6 circle
     StraySprayP4Donut = 47908, // Helper->location, 5.0s cast, range 6-40 donut
     StrayFlamesP4Donut = 47907, // Helper->location, 5.0s cast, range 6-40 donut
 

--- a/BossMod/Modules/Dawntrail/Ultimate/DMU/DMUEnums.cs
+++ b/BossMod/Modules/Dawntrail/Ultimate/DMU/DMUEnums.cs
@@ -203,6 +203,7 @@ public enum AID : uint {
     EdgeOfDeath = 50070, // Helper->self, 5.5s cast, range 48 width 2 rect
     FloodOfNaught = 50066, // 4C36->self, 5.0+0.5s cast, single-target
     FloodOfNaught1 = 50081, // NeoExdeath->self, 5.0+0.5s cast, single-target
+    FloodOfNaught2 = 50067, // NeoExdeath->self, 5.0+0.5s cast, single-target
     WhiteAntilight = 50068, // Helper->self, 5.5s cast, range 47 width 21 rect
     BlackAntilight = 50069, // Helper->self, 5.5s cast, range 47 width 21 rect
     DeathSurge = 47900, // Helper->self, no cast, range 100 circle - After Antilight casts to ensure it was solved correctly
@@ -222,7 +223,10 @@ public enum AID : uint {
 
     StrayFlamesP4 = 47906, // Helper->location, 5.0s cast, range 6 circle
     StraySprayP4 = 47909, // Helper->location, 5.0s cast, range 6 circle
+    StraySprayP4Donut = 47908, // Helper->location, 5.0s cast, range 6-40 donut
+    StrayFlamesP4Donut = 47907, // Helper->location, 5.0s cast, range 6-40 donut
 
+    _Ability_StrayEarth = 47865, // Helper->player, no cast, single-target - Gaze if you get hit most likely, but unknown
     _Ability_ThrummingThunderIII = 50654, // KefkaP4->self, 5.0s cast, single-target - can this is the cast that will be stored for later?
     _Ability_ManaRelease = 47781, // KefkaP4->self, 7.0s cast, single-target
     _Ability_BlackSpark = 48333, // Helper->player, no cast, single-target - Unknown, maybe blackhole if you walk into it?

--- a/BossMod/Modules/Dawntrail/Ultimate/DMU/DMUEnums.cs
+++ b/BossMod/Modules/Dawntrail/Ultimate/DMU/DMUEnums.cs
@@ -201,9 +201,9 @@ public enum AID : uint {
     P4Inferno1 = 47902, // 4C33->self, 9.0s cast, single-target - Applies buff to self for telling truth or lie
 
     EdgeOfDeath = 50070, // Helper->self, 5.5s cast, range 48 width 2 rect
-    FloodOfNaught = 50066, // 4C36->self, 5.0+0.5s cast, single-target
-    FloodOfNaught1 = 50081, // NeoExdeath->self, 5.0+0.5s cast, single-target
-    FloodOfNaught2 = 50067, // NeoExdeath->self, 5.0+0.5s cast, single-target
+    FloodOfNaught = 50066, // NeoExdeath->self, 5.0+0.5s cast, single-target - purple will cast  white antilight, white will cast black antilight
+    FloodOfNaught1 = 50081, // NeoExdeath->self, 5.0+0.5s cast, single-target - purple will cast black antilight, white will cast white antilight
+    FloodOfNaught2 = 50067, // NeoExdeath->self, 5.0+0.5s cast, single-target - purple will cast white antilight, white will cast black antilight
     WhiteAntilight = 50068, // Helper->self, 5.5s cast, range 47 width 21 rect
     BlackAntilight = 50069, // Helper->self, 5.5s cast, range 47 width 21 rect
     DeathSurge = 47900, // Helper->self, no cast, range 100 circle - After Antilight casts to ensure it was solved correctly
@@ -335,10 +335,10 @@ public enum SID : uint {
     AllaganField = 454, // none->player, extra=0x0
     BeyondDeath = 1382, // none->player, extra=0x0
     BeyondDeath1 = 5464, // none->player, extra=0x0
-    WhiteWound = 5541, // Helper->player, extra=0x0
-    WhiteWoundOpposite = 4887, // none->player, extra=0x0 // This is actually black lol
-    BlackWound = 5542, // Helper->player, extra=0x0
-    BlackWoundOpposite = 4888, // none->player, extra=0x0 // This is actually white lol
+    BlackWound = 4888, // none->player, extra=0x0 -> White
+    BlackWound1 = 5542, // Helper->player, extra=0x0 -> White
+    WhiteWound = 4887, // none->player, extra=0x0 -> Purple
+    WhiteWound1 = 5541, // Helper->player, extra=0x0 -> Purple
 
     ForkedLightning = 5544, // none->player, extra=0x0 - Can be either short or long (per set)
     CompressedWater = 5545, // none->player, extra=0x0 - Can be either short or long (per set)

--- a/BossMod/Modules/Dawntrail/Ultimate/DMU/DMUStates.cs
+++ b/BossMod/Modules/Dawntrail/Ultimate/DMU/DMUStates.cs
@@ -15,12 +15,12 @@ sealed class DMUStates : StateMachineBuilder {
         SimplePhase(2, Phase3, "P3")
             .SetHint(StateMachine.PhaseHint.StartWithDowntime)
             .Raw.Update = () => _module.ChaosP3()?.IsDeadOrDestroyed == true && _module.ExdeathP3()?.IsDeadOrDestroyed == true;
-        SimplePhase(3, Phase4, "P4")
+        /*SimplePhase(3, Phase4, "P4")
             .SetHint(StateMachine.PhaseHint.StartWithDowntime)
-            .Raw.Update = () => _module.KefkaP4()?.IsDeadOrDestroyed == true;
-        SimplePhase(4, Phase5, "P5")
+            .Raw.Update = () => _module.KefkaP4()?.IsDeadOrDestroyed == true;*/
+        /*SimplePhase(4, Phase5, "P5")
             .SetHint(StateMachine.PhaseHint.StartWithDowntime)
-            .Raw.Update = () => _module.KefkaP5()?.IsDeadOrDestroyed == true;
+            .Raw.Update = () => _module.KefkaP5()?.IsDeadOrDestroyed == true;*/
     }
 
     private void Phase5(uint id) {
@@ -221,8 +221,8 @@ sealed class DMUStates : StateMachineBuilder {
         ComponentCondition<UltimaUpsurge>(id + 0x166, 2.3f, o => o.NumCasts > 0, "Raidwide")
             .DeactivateOnExit<UltimaUpsurge>();
 
-        ComponentCondition<Inferno>(id + 0x170, 2.7f, o => o.NumCasts >= 8, "Inferno Baits")
-            .DeactivateOnExit<Inferno>();
+        ComponentCondition<Inferno>(id + 0x170, 2.7f, o => o.NumCasts >= 8, "Inferno Baits");
+            //.DeactivateOnExit<Inferno>();
 
         ComponentCondition<ForkedWater>(id + 0x180, 4.2f, o => o.NumCasts >= 4, "Spreads + Stacks + Acceleration Bombs Resolve")
             .DeactivateOnExit<ForkedWater>()
@@ -445,13 +445,13 @@ sealed class DMUStates : StateMachineBuilder {
         ComponentCondition<BlackHole>(id + 0x480, 7.3f, o => o.NumCasts > 21, "Tethers set 4-1")
             .ActivateOnEnter<LookUponMeAndDespairAOE>();
         ComponentCondition<BlackHole>(id + 0x490, 7.0f, o => o.NumCasts > 23, "Tethers set 4-2 + Middle line AOE")
-            .DeactivateOnExit<LookUponMeAndDespairAOE>();
+            .DeactivateOnExit<LookUponMeAndDespairAOE>()
+            .ActivateOnExit<P3Blizzard>();
 
         ActorCast(id + 0x500, _module.ExdeathP3, (uint)AID.BlizzardIIICast, 5.3f, 3.0f, true, "1st Blizzard Baits")
             .DeactivateOnEnter<KefkaMax>()
             .DeactivateOnEnter<BlackHoleActors>()
             .DeactivateOnEnter<BlackHole>()
-            .ActivateOnEnter<P3Blizzard>()
             .ActivateOnEnter<P3BlizzardBaits>()
             .ActivateOnEnter<KnockDown>()
             .ActivateOnEnter<StompAMole>();
@@ -477,6 +477,8 @@ sealed class DMUStates : StateMachineBuilder {
             .DeactivateOnExit<KnockDown>()
             .ActivateOnEnter<P3Enrage>();
         ComponentCondition<P3Enrage>(id + 0x640, 17.6f, comp => !comp.enrage, "Enrage");
+
+        Timeout(id + 0x10000, 9999.0f, "Unknown???");
     }
 
     private void Phase2(uint id) {

--- a/BossMod/Modules/Dawntrail/Ultimate/DMU/DMUStates.cs
+++ b/BossMod/Modules/Dawntrail/Ultimate/DMU/DMUStates.cs
@@ -15,12 +15,12 @@ sealed class DMUStates : StateMachineBuilder {
         SimplePhase(2, Phase3, "P3")
             .SetHint(StateMachine.PhaseHint.StartWithDowntime)
             .Raw.Update = () => _module.ChaosP3()?.IsDeadOrDestroyed == true && _module.ExdeathP3()?.IsDeadOrDestroyed == true;
-        /*SimplePhase(3, Phase4, "P4")
+        SimplePhase(3, Phase4, "P4")
             .SetHint(StateMachine.PhaseHint.StartWithDowntime)
-            .Raw.Update = () => _module.KefkaP4()?.IsDeadOrDestroyed == true;*/
-        /*SimplePhase(4, Phase5, "P5")
+            .Raw.Update = () => _module.KefkaP4()?.IsDeadOrDestroyed == true;
+        SimplePhase(4, Phase5, "P5")
             .SetHint(StateMachine.PhaseHint.StartWithDowntime)
-            .Raw.Update = () => _module.KefkaP5()?.IsDeadOrDestroyed == true;*/
+            .Raw.Update = () => _module.KefkaP5()?.IsDeadOrDestroyed == true;
     }
 
     private void Phase5(uint id) {

--- a/BossMod/Modules/Dawntrail/Ultimate/DMU/DMUStates.cs
+++ b/BossMod/Modules/Dawntrail/Ultimate/DMU/DMUStates.cs
@@ -482,10 +482,10 @@ sealed class DMUStates : StateMachineBuilder {
     private void Phase2(uint id) {
         ActorTargetable(id, _module.BossP2, true, 10.3f, "Boss appears")
             .SetHint(StateMachine.StateHint.DowntimeEnd);
-        ActorCast(id + 0x10, _module.BossP2, (uint)AID.UltimateEmbrace, 7.0f, 5.0f, true, "Tankbuster")
+        ActorCast(id + 0x10, _module.BossP2, (uint)AID.UltimateEmbrace, 7.2f, 5.0f, true, "Tankbuster")
             .ActivateOnEnter<UltimateEmbrace>()
             .DeactivateOnExit<UltimateEmbrace>();
-        ActorCast(id + 0x20, _module.BossP2, (uint)AID.Forsaken, 8.0f, 7.0f, true, "Raidwide")
+        ActorCast(id + 0x20, _module.BossP2, (uint)AID.Forsaken, 8.2f, 7.0f, true, "Raidwide")
             .ActivateOnEnter<Forsaken>()
             .DeactivateOnExit<Forsaken>()
             .ActivateOnEnter<ForsakenShapes>()
@@ -508,14 +508,13 @@ sealed class DMUStates : StateMachineBuilder {
             .ActivateOnEnter<AllThingsEnding>();
 
         // Clones baits
-        ComponentCondition<AllThingsEnding>(id + 0x50, 5.7f, o => o.NumCasts > 0, "Boss/Clones baits")
+        ComponentCondition<AllThingsEnding>(id + 0x50, 5.7f, o => o.aoesLocked, "Boss/Clones baits")
             .ExecOnExit<ForsakenSolverSet1>(s => s.colourCircle = Colors.Safe);
 
-        ComponentCondition<AllThingsEnding>(id + 0x55, 5.0f, o => o.NumCasts > 4, "Boss/Clones baits Resolve")
-            .DeactivateOnExit<AllThingsEnding>();
-
         // Tower set 3
-        ComponentCondition<ForsakenShapes>(id + 0x60, 0.4f, o => o.currentTowerSet > 3, "3rd Tower Set")
+        Condition(id + 0x60, 5.4f, () => Module.FindComponent<AllThingsEnding>()!.NumCasts >= 4 &&
+                                         Module.FindComponent<ForsakenShapes>()!.currentTowerSet > 3, "3rd Tower Set + baits")
+            .DeactivateOnExit<AllThingsEnding>()
             .DeactivateOnExit<ForsakenSolverSet1>()
             .ActivateOnExit<ForsakenSolverSet2>();
 
@@ -527,14 +526,13 @@ sealed class DMUStates : StateMachineBuilder {
             .ActivateOnEnter<AllThingsEnding>();
 
         // Clones baits
-        ComponentCondition<AllThingsEnding>(id + 0x80, 5.7f, o => o.NumCasts > 0, "Boss/Clones baits")
+        ComponentCondition<AllThingsEnding>(id + 0x80, 5.7f, o => o.aoesLocked, "Boss/Clones baits")
             .ExecOnExit<ForsakenSolverSet1>(s => s.colourCircle = Colors.Safe);
 
-        ComponentCondition<AllThingsEnding>(id + 0x85, 5.0f, o => o.NumCasts > 4, "Boss/Clones baits Resolve")
-            .DeactivateOnExit<AllThingsEnding>();
-
         // Tower set 5
-        ComponentCondition<ForsakenShapes>(id + 0x90, 0.4f, o => o.currentTowerSet > 5, "5th Tower Set")
+        Condition(id + 0x90, 5.4f, () => Module.FindComponent<AllThingsEnding>()!.NumCasts >= 4 &&
+                                         Module.FindComponent<ForsakenShapes>()!.currentTowerSet > 5, "5th Tower Set + baits")
+            .DeactivateOnExit<AllThingsEnding>()
             .DeactivateOnExit<ForsakenSolverSet1>()
             .ActivateOnExit<ForsakenSolverSet2>();
 
@@ -546,14 +544,13 @@ sealed class DMUStates : StateMachineBuilder {
             .ActivateOnEnter<AllThingsEnding>();
 
         // Clones baits
-        ComponentCondition<AllThingsEnding>(id + 0x110, 5.7f, o => o.NumCasts > 0, "Boss/Clones baits")
+        ComponentCondition<AllThingsEnding>(id + 0x110, 5.7f, o => o.aoesLocked, "Boss/Clones baits")
             .ExecOnExit<ForsakenSolverSet1>(s => s.colourCircle = Colors.Safe);
 
-        ComponentCondition<AllThingsEnding>(id + 0x115, 5.0f, o => o.NumCasts > 4, "Boss/Clones baits Resolve")
-            .DeactivateOnExit<AllThingsEnding>();
-
         // Tower set 7
-        ComponentCondition<ForsakenShapes>(id + 0x120, 0.4f, o => o.currentTowerSet > 7, "7th Tower Set")
+        Condition(id + 0x120, 5.4f, () => Module.FindComponent<AllThingsEnding>()!.NumCasts >= 4 &&
+                                         Module.FindComponent<ForsakenShapes>()!.currentTowerSet > 7, "7th Tower Set + baits")
+            .DeactivateOnExit<AllThingsEnding>()
             .DeactivateOnExit<ForsakenSolverSet1>()
             .ActivateOnExit<ForsakenSolverSet2>();
 
@@ -563,9 +560,9 @@ sealed class DMUStates : StateMachineBuilder {
             .ActivateOnEnter<AllThingsEnding>();
 
         // Clones baits
-        ComponentCondition<AllThingsEnding>(id + 0x140, 5.4f, o => o.NumCasts > 0, "Boss/Clones baits");
+        ComponentCondition<AllThingsEnding>(id + 0x140, 5.4f, o => o.aoesLocked, "Boss/Clones baits");
 
-        ComponentCondition<AllThingsEnding>(id + 0x145, 5.0f, o => o.NumCasts > 7, "Boss/Clones baits Resolve")
+        ComponentCondition<AllThingsEnding>(id + 0x145, 5.2f, o => o.NumCasts >= 4, "Boss/Clones baits Resolve")
             .DeactivateOnExit<ForsakenShapes>()
             .DeactivateOnExit<ForsakenBaitsSpreadStacks>()
             .DeactivateOnExit<ForsakenBaitsCone>()
@@ -590,7 +587,7 @@ sealed class DMUStates : StateMachineBuilder {
             .DeactivateOnExit<Trine>();
         ComponentCondition<WingsOfDestructionTB>(id + 0x220, 0.6f, o => o.NumCasts > 0, "Tankbuster")
             .DeactivateOnExit<WingsOfDestructionTB>();
-        ActorCast(id + 0x220, _module.BossP2, (uint)AID.UltimateEmbrace, 2.0f, 5.0f, true, "Tankbuster")
+        ActorCast(id + 0x220, _module.BossP2, (uint)AID.UltimateEmbrace, 2.1f, 5.0f, true, "Tankbuster")
             .ActivateOnEnter<UltimateEmbrace>()
             .DeactivateOnExit<UltimateEmbrace>();
 

--- a/BossMod/Modules/Dawntrail/Ultimate/DMU/DMUStates.cs
+++ b/BossMod/Modules/Dawntrail/Ultimate/DMU/DMUStates.cs
@@ -15,12 +15,12 @@ sealed class DMUStates : StateMachineBuilder {
         SimplePhase(2, Phase3, "P3")
             .SetHint(StateMachine.PhaseHint.StartWithDowntime)
             .Raw.Update = () => _module.ChaosP3()?.IsDeadOrDestroyed == true && _module.ExdeathP3()?.IsDeadOrDestroyed == true;
-        SimplePhase(3, Phase4, "P4")
+        /*SimplePhase(3, Phase4, "P4")
             .SetHint(StateMachine.PhaseHint.StartWithDowntime)
             .Raw.Update = () => _module.KefkaP4()?.IsDeadOrDestroyed == true;
         SimplePhase(4, Phase5, "P5")
             .SetHint(StateMachine.PhaseHint.StartWithDowntime)
-            .Raw.Update = () => _module.KefkaP5()?.IsDeadOrDestroyed == true;
+            .Raw.Update = () => _module.KefkaP5()?.IsDeadOrDestroyed == true;*/
     }
 
     private void Phase5(uint id) {
@@ -185,11 +185,11 @@ sealed class DMUStates : StateMachineBuilder {
         ComponentCondition<GrandCrossOrder>(id + 0x110, 4.2f, o => o.currentCast > 2, "Raidwide (3rd Grand Cross)")
             .ActivateOnEnter<GrandCrossRaidwide>()
             .DeactivateOnExit<GrandCrossRaidwide>()
-            .ActivateOnExit<Antilight>()
+            .ActivateOnExit<AntiLight>()
             .ActivateOnExit<EdgeOfDeath>();
 
-        ComponentCondition<Antilight>(id + 0x120, 12.6f, o => o.NumCasts >= 4, "Antilight + Edge of Death")
-            .DeactivateOnExit<Antilight>()
+        ComponentCondition<AntiLight>(id + 0x120, 12.6f, o => o.NumCasts >= 4, "Antilight + Edge of Death")
+            .DeactivateOnExit<AntiLight>()
             .DeactivateOnExit<EdgeOfDeath>()
             .ActivateOnExit<ForkedWater>()
             .ActivateOnExit<AccelerationBomb>();

--- a/BossMod/Modules/Dawntrail/Ultimate/DMU/DMUStates.cs
+++ b/BossMod/Modules/Dawntrail/Ultimate/DMU/DMUStates.cs
@@ -235,7 +235,8 @@ sealed class DMUStates : StateMachineBuilder {
 
         ComponentCondition<CursedShriek>(id + 0x200, 7.1f, o => o.NumCasts > 0, "Gazes Resolve")
             .DeactivateOnExit<CursedShriek>()
-            .ActivateOnExit<Tsunami>();
+            .ActivateOnExit<Tsunami>()
+            .ActivateOnExit<TsunamiBaits>();
 
         ComponentCondition<Tsunami>(id + 0x210, 10.7f, o => o.NumCasts >= 8, "Tsunami Baits")
             .DeactivateOnExit<Tsunami>()
@@ -477,8 +478,6 @@ sealed class DMUStates : StateMachineBuilder {
             .DeactivateOnExit<KnockDown>()
             .ActivateOnEnter<P3Enrage>();
         ComponentCondition<P3Enrage>(id + 0x640, 17.6f, comp => !comp.enrage, "Enrage");
-
-        Timeout(id + 0x10000, 9999.0f, "Unknown???");
     }
 
     private void Phase2(uint id) {

--- a/BossMod/Modules/Dawntrail/Ultimate/DMU/Phase2.cs
+++ b/BossMod/Modules/Dawntrail/Ultimate/DMU/Phase2.cs
@@ -880,7 +880,7 @@ class AllThingsEnding(BossModule module) : Components.SimpleAOEs(module, (uint)A
     private List<Actor> baiters = [];
     private enum _bait { None, Far, Close }
     private _bait currentBait = _bait.None;
-    private bool aoesLocked = false;
+    public bool aoesLocked = false;
 
     // If this mechanic is ever rewritten, please include a way to handle tower storing for the final set; some strategies
     // include using the two last towers for the mechanic, some will simply just use a waymark
@@ -903,11 +903,13 @@ class AllThingsEnding(BossModule module) : Components.SimpleAOEs(module, (uint)A
 
         if (spell.Action.ID == (uint)AID.AllThingsEnding || spell.Action.ID == (uint)AID.AllThingsEnding1) {
             aoesLocked = true;
-            NumCasts++;
         }
     }
 
     public override void OnEventCast(Actor caster, ActorCastEvent spell) {
+        Service.Logger.Info("Cast id " + spell.Action.ID + "cast name " + spell.Action.Name());
+
+
         if (spell.Action.ID == (uint)AID.PastsEndSpread || spell.Action.ID == (uint)AID.PastsEndSpread1 ||
             spell.Action.ID == (uint)AID.FuturesEndSpread || spell.Action.ID == (uint)AID.FuturesEndSpread1) {
             clones.Add((caster, spell.MainTargetID));
@@ -915,6 +917,7 @@ class AllThingsEnding(BossModule module) : Components.SimpleAOEs(module, (uint)A
 
         if (spell.Action.ID == (uint)AID.AllThingsEnding || spell.Action.ID == (uint)AID.AllThingsEnding1) {
             NumCasts++;
+            Service.Logger.Info("Num casts " + NumCasts);
             aoes.Clear();
             baiters.Clear();
         }
@@ -1124,8 +1127,18 @@ class Trine(BossModule module) : Components.GenericAOEs(module, (uint)AID.Trine)
         var waymark1Angle = (waymark1.Value.ToWPos() - Arena.Center).ToAngle();
         var firstWave = triangles.Take(3).Select(t => t.Position).ToArray();
 
+        Array.Sort(firstWave, delegate(WPos x, WPos y) {
+            var xAngle = (x - Arena.Center).ToAngle();
+            var yAngle = (y - Arena.Center).ToAngle();
+
+            var xDeg = xAngle.AlmostEqual(waymarkAAngle, 0.01f) ? 180f : (xAngle - waymarkAAngle + 180f.Degrees()).Normalized().Deg;
+            var yDeg = yAngle.AlmostEqual(waymarkAAngle, 0.01f) ? 180f : (yAngle - waymarkAAngle + 180f.Degrees()).Normalized().Deg;
+
+            return xDeg < yDeg ? 1 : -1;
+        });
+
         if (assignment != PartyRolesConfig.Assignment.MT && assignment != PartyRolesConfig.Assignment.OT) {
-            Arena.AddCircle(firstWave.MinBy(p => ((p - Arena.Center).ToAngle() - waymarkAAngle).Normalized().Deg)!, 1f, Colors.Safe, 2f);
+            Arena.AddCircle(firstWave[0], 1f, Colors.Safe, 2f);
             return;
         }
 

--- a/BossMod/Modules/Dawntrail/Ultimate/DMU/Phase3.cs
+++ b/BossMod/Modules/Dawntrail/Ultimate/DMU/Phase3.cs
@@ -930,6 +930,7 @@ class P3BlizzardBaits(BossModule module) : Components.SimpleAOEs(module, (uint)A
 
 class P3Blizzard(BossModule module) : Components.GenericBaitAway(module, centerAtTarget: true, onlyShowOutlines: true) {
     private Actor? boss = null;
+    private readonly PartyRolesConfig partyConfig = Service.Config.Get<PartyRolesConfig>();
 
     public override void OnCastStarted(Actor caster, ActorCastInfo spell) {
         if (spell.Action.ID == (uint)AID.BlizzardIIICast) {
@@ -954,6 +955,69 @@ class P3Blizzard(BossModule module) : Components.GenericBaitAway(module, centerA
 
         foreach (var player in Raid.WithoutSlot()) {
             CurrentBaits.Add(new(boss, player, new AOEShapeCircle(6.0f)));
+        }
+    }
+
+    public override void DrawArenaForeground(int pcSlot, Actor pc) {
+        base.DrawArenaForeground(pcSlot, pc);
+
+        if (NumCasts >= 16) { // TODO remove this when adding hints array
+            return;
+        }
+
+        var kefkaBoss = ((DMU)Module).BossP3();
+        if (kefkaBoss == null) {
+            return;
+        }
+
+        var slots = partyConfig.SlotsPerAssignment(Raid);
+        if (slots.Length == 0) {
+            return;
+        }
+        var assignment = partyConfig[Raid.Members[pcSlot].ContentId];
+
+        if (pc.Class.IsDD()) {
+            if (NumCasts < 8) {
+                Arena.AddCircle(kefkaBoss.Position + 10.0f * kefkaBoss.Rotation.ToDirection(), 1.0f, Colors.Safe);
+            }
+
+            if (assignment == PartyRolesConfig.Assignment.M1 || assignment == PartyRolesConfig.Assignment.R1) {
+                if (NumCasts < 8) {
+                    Arena.AddCircle((kefkaBoss.Position + 10.0f * kefkaBoss.Rotation.ToDirection()) - 8.0f * kefkaBoss.Rotation.ToDirection().OrthoL(), 1.0f, Colors.Danger);
+                } else {
+                    Arena.AddCircle((kefkaBoss.Position + 10.0f * kefkaBoss.Rotation.ToDirection()) - 8.0f * kefkaBoss.Rotation.ToDirection().OrthoL(), 1.0f, Colors.Safe);
+                }
+            }
+
+            if (assignment == PartyRolesConfig.Assignment.M2 || assignment == PartyRolesConfig.Assignment.R2) {
+                if (NumCasts < 8) {
+                    Arena.AddCircle((kefkaBoss.Position + 10.0f * kefkaBoss.Rotation.ToDirection()) + 8.0f * kefkaBoss.Rotation.ToDirection().OrthoL(), 1.0f, Colors.Danger);
+                } else {
+                    Arena.AddCircle((kefkaBoss.Position + 10.0f * kefkaBoss.Rotation.ToDirection()) + 8.0f * kefkaBoss.Rotation.ToDirection().OrthoL(), 1.0f, Colors.Safe);
+                }
+            }
+        }
+
+        if (pc.Class.IsSupport()) {
+            if (NumCasts < 8) {
+                Arena.AddCircle(kefkaBoss.Position - 10.0f * kefkaBoss.Rotation.ToDirection(), 1.0f, Colors.Safe);
+            }
+
+            if (assignment == PartyRolesConfig.Assignment.MT || assignment == PartyRolesConfig.Assignment.H1) {
+                if (NumCasts < 8) {
+                    Arena.AddCircle((kefkaBoss.Position - 10.0f * kefkaBoss.Rotation.ToDirection()) - 8.0f * kefkaBoss.Rotation.ToDirection().OrthoL(), 1.0f, Colors.Danger);
+                } else {
+                    Arena.AddCircle((kefkaBoss.Position - 10.0f * kefkaBoss.Rotation.ToDirection()) - 8.0f * kefkaBoss.Rotation.ToDirection().OrthoL(), 1.0f, Colors.Safe);
+                }
+            }
+
+            if (assignment == PartyRolesConfig.Assignment.OT || assignment == PartyRolesConfig.Assignment.H2) {
+                if (NumCasts < 8) {
+                    Arena.AddCircle((kefkaBoss.Position - 10.0f * kefkaBoss.Rotation.ToDirection()) + 8.0f * kefkaBoss.Rotation.ToDirection().OrthoL(), 1.0f, Colors.Danger);
+                } else {
+                    Arena.AddCircle((kefkaBoss.Position - 10.0f * kefkaBoss.Rotation.ToDirection()) + 8.0f * kefkaBoss.Rotation.ToDirection().OrthoL(), 1.0f, Colors.Safe);
+                }
+            }
         }
     }
 }

--- a/BossMod/Modules/Dawntrail/Ultimate/DMU/Phase4.cs
+++ b/BossMod/Modules/Dawntrail/Ultimate/DMU/Phase4.cs
@@ -409,7 +409,7 @@ class AccelerationBomb(BossModule module) : Components.StayMove(module) {
         }
 
         // TODO fix this
-        /*foreach (var (slot, expireAt, tellingTruth) in grandCrossOrder.getNextBuffPlayers(SID.AccelerationBomb, 4)) {
+        foreach (var (slot, expireAt, tellingTruth) in grandCrossOrder.getNextBuffPlayers(SID.AccelerationBomb, 4)) {
             if ((expireAt - WorldState.CurrentTime).TotalSeconds > 7.0f) {
                 continue;
             }
@@ -421,7 +421,7 @@ class AccelerationBomb(BossModule module) : Components.StayMove(module) {
             if (tellingTruth == false) {
                 PlayerStates[slot] = new(Requirement.Move, expireAt);
             }
-        }*/
+        }
     }
 }
 
@@ -574,23 +574,29 @@ class CursedShriek(BossModule module) : Components.GenericGaze(module) {
 class InfernoBaits(BossModule module) : Components.SimpleAOEs(module, (uint)AID.StrayFlamesP4, new AOEShapeCircle(6.0f)) {
     private Inferno? inferno = module.FindComponent<Inferno>();
 
-    public override void OnCastStarted(Actor caster, ActorCastInfo spell)
-    {
+    public override void OnCastStarted(Actor caster, ActorCastInfo spell) {
+        if (inferno == null || inferno.truth == null) {
+            return;
+        }
+
         if (spell.Action.ID == (uint)AID.StrayFlamesP4) {
-            if (inferno != null) {
-                if (inferno.truth == true) {
-                    Casters.Add(new(Shape, caster.Position, caster.Rotation));
-                }
+            // Real
+            if (inferno.truth == true) {
+                Casters.Add(new(Shape, caster.Position, caster.Rotation, actorID: caster.InstanceID));
+            }
+
+            // Fake
+            if (inferno.truth == false) {
+                Casters.Add(new(new AOEShapeDonut(3.0f, 10.0f), caster.Position, caster.Rotation, actorID: caster.InstanceID));
             }
         }
     }
 }
 
-// TODO move eventcast to baits function instead
-class Inferno(BossModule module) : Components.GenericBaitProximity(module) {
+class Inferno(BossModule module) : Components.GenericBaitProximity(module, onlyShowOutlines: true) {
     private TsunamiInfernoOrder? tsunamiInfernoOrder = module.FindComponent<TsunamiInfernoOrder>();
     public bool active = false;
-    public bool? truth = null; // TODO fix how this component actually works for the baits
+    public bool? truth = null;
 
     public override void OnCastStarted(Actor caster, ActorCastInfo spell) {
         if (spell.Action.ID == (uint)AID.StrayFlamesP4) {
@@ -599,25 +605,16 @@ class Inferno(BossModule module) : Components.GenericBaitProximity(module) {
         }
     }
 
-    public override void OnEventCast(Actor caster, ActorCastEvent spell) {
-        if (spell.Action.ID == (uint)AID.StrayFlamesP4) {
-            CurrentBaits.Clear();
-            NumCasts++;
-        }
-    }
-
     public override void Update() {
-        if (tsunamiInfernoOrder == null) {
+        if (tsunamiInfernoOrder == null || active == true) {
             return;
         }
 
         var players = tsunamiInfernoOrder.getNextBuffPlayers(SID.EntropyP4, 8);
         if (players.Count == 0) {
-            OnlyShowOutlines = false;
             return;
         }
 
-        OnlyShowOutlines = true;
         CurrentBaits.Clear();
 
         foreach (var (slot, expireAt, tellingTruth) in players) {
@@ -629,11 +626,13 @@ class Inferno(BossModule module) : Components.GenericBaitProximity(module) {
             // Real
             if (tellingTruth == true) {
                 CurrentBaits.Add(new(player.Position, new AOEShapeCircle(6.0f)));
+                truth = true;
             }
 
             // Fake
             if (tellingTruth == false) {
-                CurrentBaits.Add(new(player.Position, new AOEShapeDonut(3.0f, 6.0f))); // TODO aoe size is a guess for now
+                CurrentBaits.Add(new(player.Position, new AOEShapeDonut(3.0f, 10.0f))); // TODO check size of aoe
+                truth = false;
             }
         }
     }
@@ -647,35 +646,38 @@ class Inferno(BossModule module) : Components.GenericBaitProximity(module) {
     }
 }
 
-class Tsunami(BossModule module) : Components.GenericBaitProximity(module) {
+class TsunamiBaits(BossModule module) : Components.SimpleAOEs(module, (uint)AID.StraySprayP4, new AOEShapeCircle(6.0f)) {
+    private Tsunami? tsunami = module.FindComponent<Tsunami>();
+
+    public override void OnCastStarted(Actor caster, ActorCastInfo spell) {
+        if (tsunami == null || tsunami.truth == null) {
+            return;
+        }
+    }
+}
+
+class Tsunami(BossModule module) : Components.GenericBaitProximity(module, onlyShowOutlines: true) {
     private TsunamiInfernoOrder? tsunamiInfernoOrder = module.FindComponent<TsunamiInfernoOrder>();
     public bool active = false;
+    public bool? truth = null;
 
     public override void OnCastStarted(Actor caster, ActorCastInfo spell) {
         if (spell.Action.ID == (uint)AID.StraySprayP4) {
+            CurrentBaits.Clear();
             active = true;
         }
     }
 
-    public override void OnEventCast(Actor caster, ActorCastEvent spell) {
-        if (spell.Action.ID == (uint)AID.StraySprayP4) {
-            CurrentBaits.Clear();
-            NumCasts++;
-        }
-    }
-
     public override void Update() {
-        if (tsunamiInfernoOrder == null) {
+        if (tsunamiInfernoOrder == null || active == true) {
             return;
         }
 
         var players = tsunamiInfernoOrder.getNextBuffPlayers(SID.DynamicFluidP4, 8);
         if (players.Count == 0) {
-            OnlyShowOutlines = false;
             return;
         }
 
-        OnlyShowOutlines = true;
         CurrentBaits.Clear();
 
         foreach (var (slot, expireAt, tellingTruth) in players) {
@@ -684,13 +686,16 @@ class Tsunami(BossModule module) : Components.GenericBaitProximity(module) {
                 continue;
             }
 
+            // Real
             if (tellingTruth == true) {
-                CurrentBaits.Add(new(player.Position, new AOEShapeDonut(3.0f, 6.0f))); // TODO aoe size is a guess for now
+                CurrentBaits.Add(new(player.Position, new AOEShapeDonut(3.0f, 10.0f))); // TODO aoe size is a guess for now
+                truth = true;
             }
 
             // Fake
             if (tellingTruth == false) {
                 CurrentBaits.Add(new(player.Position, new AOEShapeCircle(6.0f)));
+                truth = false;
             }
         }
     }

--- a/BossMod/Modules/Dawntrail/Ultimate/DMU/Phase4.cs
+++ b/BossMod/Modules/Dawntrail/Ultimate/DMU/Phase4.cs
@@ -571,35 +571,37 @@ class CursedShriek(BossModule module) : Components.GenericGaze(module) {
     }
 }
 
-class InfernoBaits(BossModule module) : Components.SimpleAOEs(module, (uint)AID.StrayFlamesP4, new AOEShapeCircle(6.0f)) {
-    private Inferno? inferno = module.FindComponent<Inferno>();
+class InfernoBaits(BossModule module) : Components.GenericAOEs(module) {
+    private List<AOEInstance> aoes = [];
 
     public override void OnCastStarted(Actor caster, ActorCastInfo spell) {
-        if (inferno == null || inferno.truth == null) {
-            return;
+        if (spell.Action.ID == (uint)AID.StrayFlamesP4Puddle) {
+            aoes.Add(new(new AOEShapeCircle(6.0f), caster.Position, caster.Rotation, actorID: caster.InstanceID));
         }
 
-        if (spell.Action.ID == (uint)AID.StrayFlamesP4) {
-            // Real
-            if (inferno.truth == true) {
-                Casters.Add(new(Shape, caster.Position, caster.Rotation, actorID: caster.InstanceID));
-            }
-
-            // Fake
-            if (inferno.truth == false) {
-                Casters.Add(new(new AOEShapeDonut(3.0f, 10.0f), caster.Position, caster.Rotation, actorID: caster.InstanceID));
-            }
+        if (spell.Action.ID == (uint)AID.StrayFlamesP4Donut) {
+            aoes.Add(new(new AOEShapeDonut(6.0f, 40.0f), caster.Position, caster.Rotation, actorID: caster.InstanceID));
         }
+    }
+
+    public override void OnEventCast(Actor caster, ActorCastEvent spell) {
+        if (spell.Action.ID == (uint)AID.StrayFlamesP4Puddle || spell.Action.ID == (uint)AID.StrayFlamesP4Donut) {
+            aoes.RemoveAll(aoe => aoe.ActorID == caster.InstanceID);
+            NumCasts++;
+        }
+    }
+
+    public override ReadOnlySpan<AOEInstance> ActiveAOEs(int slot, Actor actor) {
+        return CollectionsMarshal.AsSpan(aoes);
     }
 }
 
 class Inferno(BossModule module) : Components.GenericBaitProximity(module, onlyShowOutlines: true) {
     private TsunamiInfernoOrder? tsunamiInfernoOrder = module.FindComponent<TsunamiInfernoOrder>();
     public bool active = false;
-    public bool? truth = null;
 
     public override void OnCastStarted(Actor caster, ActorCastInfo spell) {
-        if (spell.Action.ID == (uint)AID.StrayFlamesP4) {
+        if (spell.Action.ID == (uint)AID.StrayFlamesP4Puddle || spell.Action.ID == (uint)AID.StrayFlamesP4Donut) {
             CurrentBaits.Clear();
             active = true;
         }
@@ -626,13 +628,11 @@ class Inferno(BossModule module) : Components.GenericBaitProximity(module, onlyS
             // Real
             if (tellingTruth == true) {
                 CurrentBaits.Add(new(player.Position, new AOEShapeCircle(6.0f)));
-                truth = true;
             }
 
             // Fake
             if (tellingTruth == false) {
-                CurrentBaits.Add(new(player.Position, new AOEShapeDonut(3.0f, 10.0f))); // TODO check size of aoe
-                truth = false;
+                CurrentBaits.Add(new(player.Position, new AOEShapeDonut(6.0f, 40.0f)));
             }
         }
     }
@@ -646,23 +646,37 @@ class Inferno(BossModule module) : Components.GenericBaitProximity(module, onlyS
     }
 }
 
-class TsunamiBaits(BossModule module) : Components.SimpleAOEs(module, (uint)AID.StraySprayP4, new AOEShapeCircle(6.0f)) {
-    private Tsunami? tsunami = module.FindComponent<Tsunami>();
+class TsunamiBaits(BossModule module) : Components.GenericAOEs(module) {
+    private List<AOEInstance> aoes = [];
 
     public override void OnCastStarted(Actor caster, ActorCastInfo spell) {
-        if (tsunami == null || tsunami.truth == null) {
-            return;
+        if (spell.Action.ID == (uint)AID.StraySprayP4Puddle) {
+            aoes.Add(new(new AOEShapeCircle(6.0f), caster.Position, caster.Rotation, actorID: caster.InstanceID));
         }
+
+        if (spell.Action.ID == (uint)AID.StraySprayP4Donut) {
+            aoes.Add(new(new AOEShapeDonut(6.0f, 40.0f), caster.Position, caster.Rotation, actorID: caster.InstanceID));
+        }
+    }
+
+    public override void OnEventCast(Actor caster, ActorCastEvent spell) {
+        if (spell.Action.ID == (uint)AID.StraySprayP4Puddle || spell.Action.ID == (uint)AID.StraySprayP4Donut) {
+            aoes.RemoveAll(aoe => aoe.ActorID == caster.InstanceID);
+            NumCasts++;
+        }
+    }
+
+    public override ReadOnlySpan<AOEInstance> ActiveAOEs(int slot, Actor actor) {
+        return CollectionsMarshal.AsSpan(aoes);
     }
 }
 
 class Tsunami(BossModule module) : Components.GenericBaitProximity(module, onlyShowOutlines: true) {
     private TsunamiInfernoOrder? tsunamiInfernoOrder = module.FindComponent<TsunamiInfernoOrder>();
     public bool active = false;
-    public bool? truth = null;
 
     public override void OnCastStarted(Actor caster, ActorCastInfo spell) {
-        if (spell.Action.ID == (uint)AID.StraySprayP4) {
+        if (spell.Action.ID == (uint)AID.StraySprayP4Puddle || spell.Action.ID == (uint)AID.StraySprayP4Donut) {
             CurrentBaits.Clear();
             active = true;
         }
@@ -688,14 +702,12 @@ class Tsunami(BossModule module) : Components.GenericBaitProximity(module, onlyS
 
             // Real
             if (tellingTruth == true) {
-                CurrentBaits.Add(new(player.Position, new AOEShapeDonut(3.0f, 10.0f))); // TODO aoe size is a guess for now
-                truth = true;
+                CurrentBaits.Add(new(player.Position, new AOEShapeDonut(6.0f, 40.0f)));
             }
 
             // Fake
             if (tellingTruth == false) {
                 CurrentBaits.Add(new(player.Position, new AOEShapeCircle(6.0f)));
-                truth = false;
             }
         }
     }

--- a/BossMod/Modules/Dawntrail/Ultimate/DMU/Phase4.cs
+++ b/BossMod/Modules/Dawntrail/Ultimate/DMU/Phase4.cs
@@ -31,8 +31,8 @@ class GrandCrossOrder(BossModule module) : BossComponent(module) {
 
         if (status.ID == (uint)SID.BeyondDeath || status.ID == (uint)SID.BeyondDeath1 ||
             status.ID == (uint)SID.AllaganField ||
-            status.ID == (uint)SID.WhiteWound || status.ID == (uint)SID.WhiteWoundOpposite ||
-            status.ID == (uint)SID.BlackWound || status.ID == (uint)SID.BlackWoundOpposite ) {
+            status.ID == (uint)SID.WhiteWound || status.ID == (uint)SID.WhiteWound1 ||
+            status.ID == (uint)SID.BlackWound || status.ID == (uint)SID.BlackWound1) {
             var slot = Raid.FindSlot(actor.InstanceID);
             if (slot >= 0) {
                 var id = grandCross.FindIndex(e => e.set == NumCasts - 1);
@@ -57,8 +57,8 @@ class GrandCrossOrder(BossModule module) : BossComponent(module) {
     public override void OnStatusLose(Actor actor, ref ActorStatus status) {
         if (status.ID == (uint)SID.BeyondDeath || status.ID == (uint)SID.BeyondDeath1 ||
             status.ID == (uint)SID.AllaganField ||
-            status.ID == (uint)SID.WhiteWound || status.ID == (uint)SID.WhiteWoundOpposite ||
-            status.ID == (uint)SID.BlackWound || status.ID == (uint)SID.BlackWoundOpposite ||
+            status.ID == (uint)SID.WhiteWound || status.ID == (uint)SID.WhiteWound1 ||
+            status.ID == (uint)SID.BlackWound || status.ID == (uint)SID.BlackWound1 ||
             status.ID == (uint)SID.ForkedLightning || status.ID == (uint)SID.CompressedWater ||
             status.ID == (uint)SID.AccelerationBomb || status.ID == (uint)SID.CursedShriek) {
             var slot = Raid.FindSlot(actor.InstanceID);
@@ -206,36 +206,43 @@ class EdgeOfDeath(BossModule module) : Components.SimpleAOEs(module, (uint)AID.E
 
 // TODO fix AOE middle line - small aoe line where you cant stand at all, but can be done later there is a lot of free space
 // TODO change to simple AOEs at some point maybe - so it has built-in NumCasts
-class Antilight(BossModule module) : BossComponent(module) {
-    private Actor? whiteAntilight = null;
-    private Actor? blackAntilight = null;
+// You can most likely actually figure out which debuffs go with which cast and make it simpler, but unsure
+class AntiLight(BossModule module) : BossComponent(module) {
+    private Actor? whiteAntiLight = null;
+    private Actor? blackAntiLight = null;
     private bool? tellingTruth = null;
+    private uint? spellID = null;
+    private bool swapped = false;
     private GrandCrossOrder? grandCrossOrder = module.FindComponent<GrandCrossOrder>();
     public int NumCasts = 0;
 
     public override void OnCastStarted(Actor caster, ActorCastInfo spell) {
         if (spell.Action.ID == (uint)AID.WhiteAntilight) {
-            whiteAntilight = caster;
+            whiteAntiLight = caster;
         }
 
         if (spell.Action.ID == (uint)AID.BlackAntilight) {
-            blackAntilight = caster;
+            blackAntiLight = caster;
+        }
+
+        if (spell.Action.ID == (uint)AID.FloodOfNaught || spell.Action.ID == (uint)AID.FloodOfNaught1 || spell.Action.ID == (uint)AID.FloodOfNaught2) {
+            spellID = spell.Action.ID;
         }
     }
 
     public override void OnCastFinished(Actor caster, ActorCastInfo spell) {
         if (spell.Action.ID == (uint)AID.WhiteAntilight) {
-            whiteAntilight = null;
+            whiteAntiLight = null;
             NumCasts++;
         }
 
         if (spell.Action.ID == (uint)AID.BlackAntilight) {
-            blackAntilight = null;
+            blackAntiLight = null;
             NumCasts++;
         }
 
         if (spell.Action.ID == (uint)AID.FloodOfNaught || spell.Action.ID == (uint)AID.FloodOfNaught1 ||
-            spell.Action.ID == (uint)AID.EdgeOfDeath) {
+            spell.Action.ID == (uint)AID.FloodOfNaught2 || spell.Action.ID == (uint)AID.EdgeOfDeath) {
             NumCasts++;
         }
     }
@@ -252,33 +259,54 @@ class Antilight(BossModule module) : BossComponent(module) {
         }
     }
 
-    public override void DrawArenaForeground(int pcSlot, Actor pc) {
-        if (grandCrossOrder == null || whiteAntilight == null || blackAntilight == null || tellingTruth == null) {
+    public override void Update() {
+        if (whiteAntiLight == null || blackAntiLight == null || spellID == null) {
             return;
         }
 
-        var buffs = grandCrossOrder.getCurrentPlayerBuffs(pcSlot, 2); // sets are 0, 1, 2
+        // Depending on the flood ID cast, the orbs will cast the opposite of what they actually are
+        if ((spellID == (uint)AID.FloodOfNaught ||spellID == (uint)AID.FloodOfNaught2) && swapped == false) {
+            (whiteAntiLight, blackAntiLight) = (blackAntiLight, whiteAntiLight);
+            swapped = true;
+        }
+    }
+
+    public override void DrawArenaForeground(int pcSlot, Actor pc) {
+        if (grandCrossOrder == null || whiteAntiLight == null || blackAntiLight == null || tellingTruth == null || spellID == null) {
+            return;
+        }
+
+        var buffs = grandCrossOrder.getCurrentPlayerBuffs(pcSlot, 2); // Sets are 0, 1, 2, and AntiLight is always the final set
         if (buffs == null) {
             return;
         }
 
+        // TODO This should never happen - most likely can be removed, as buffs will always be there by the time casters are set
         if (!hasBuff(buffs, SID.BeyondDeath) && !hasBuff(buffs, SID.BeyondDeath1) &&
             !hasBuff(buffs, SID.AllaganField)) {
             return;
         }
 
-        Actor correctSide;
-        Actor wrongSide;
+        Actor? correctSide = null;
+        Actor? wrongSide = null;
 
         if (hasBuff(buffs, SID.BeyondDeath) || hasBuff(buffs, SID.BeyondDeath1)) {
-            correctSide = (hasBuff(buffs, SID.WhiteWound) || hasBuff(buffs, SID.BlackWoundOpposite)) ? whiteAntilight : blackAntilight;
-            wrongSide = (hasBuff(buffs, SID.WhiteWound) || hasBuff(buffs, SID.BlackWoundOpposite)) ? blackAntilight : whiteAntilight;
-        } else {
-            correctSide = (hasBuff(buffs, SID.WhiteWound) || hasBuff(buffs, SID.BlackWoundOpposite)) ? blackAntilight : whiteAntilight;
-            wrongSide = (hasBuff(buffs, SID.WhiteWound) || hasBuff(buffs, SID.BlackWoundOpposite)) ? whiteAntilight : blackAntilight;
+            var requireWhite = hasBuff(buffs, SID.BlackWound) || hasBuff(buffs, SID.BlackWound1);
+            correctSide = requireWhite ? whiteAntiLight : blackAntiLight;
+            wrongSide = requireWhite ? blackAntiLight : whiteAntiLight;
         }
 
-        // If it was a lie, flip it
+        if (hasBuff(buffs, SID.AllaganField)) {
+            var requireWhite = hasBuff(buffs, SID.BlackWound) || hasBuff(buffs, SID.BlackWound1);
+            correctSide = requireWhite ? blackAntiLight : whiteAntiLight;
+            wrongSide = requireWhite ? whiteAntiLight : blackAntiLight;
+        }
+
+        if (correctSide == null || wrongSide == null) {
+            return;
+        }
+
+        // Fake = swap
         if (tellingTruth == false) {
             (correctSide, wrongSide) = (wrongSide, correctSide);
         }


### PR DESCRIPTION
- Fixed safe spots for the party group during trines
- Fixed forsaken baits & towers timeline, sometimes drifting out of place
- Turned off phases 4 & 5 - Will be enabled again once I have confirmed they're working myself as I prog the fight