### PR TITLE
changing past/future bait visual to be less crowded

### DIFF
--- a/BossMod/Modules/Dawntrail/Ultimate/DMU/Phase2.cs
+++ b/BossMod/Modules/Dawntrail/Ultimate/DMU/Phase2.cs
@@ -959,13 +959,6 @@ class AllThingsEnding(BossModule module) : Components.SimpleAOEs(module, (uint)A
     public override void DrawArenaForeground(int pcSlot, Actor pc) {
         base.DrawArenaForeground(pcSlot, pc);
 
-        if (aoesLocked == false) {
-            foreach (var aoe in aoes)
-            {
-                aoe.Shape.Outline(Arena, aoe.Origin, aoe.Rotation, aoe.Color, 0.5f);
-            }
-        }
-
         if (aoesLocked == true)
         {
             return;
@@ -973,6 +966,13 @@ class AllThingsEnding(BossModule module) : Components.SimpleAOEs(module, (uint)A
 
         if (towers == null || shapes == null) {
             return;
+        }
+
+        if (aoesLocked == false) {
+            foreach (var aoe in aoes)
+            {
+                aoe.Shape.Outline(Arena, aoe.Origin, aoe.Rotation, aoe.Color, 0.5f);
+            }
         }
 
         // TODO change this - its a lazy way of checking if we should draw the hint or not yet for past/future ending

--- a/BossMod/Modules/Dawntrail/Ultimate/DMU/Phase2.cs
+++ b/BossMod/Modules/Dawntrail/Ultimate/DMU/Phase2.cs
@@ -942,16 +942,32 @@ class AllThingsEnding(BossModule module) : Components.SimpleAOEs(module, (uint)A
             if (currentBait == _bait.Close) {
                 direction = direction + 180.Degrees();
             }
-            aoes.Add(new(new AOEShapeCone(100, 90.Degrees()), clone.Position, direction));
+            aoes.Add(new(new AOEShapeCone(20, 90.Degrees()), clone.Position, direction));
         }
 
         return CollectionsMarshal.AsSpan(aoes);
     }
 
+    public override void DrawArenaBackground(int pcSlot, Actor pc)
+    {
+        if (aoesLocked == true)
+        {
+            base.DrawArenaBackground(pcSlot, pc);
+        }
+    }
+    
     public override void DrawArenaForeground(int pcSlot, Actor pc) {
         base.DrawArenaForeground(pcSlot, pc);
 
-        if (aoesLocked == true) {
+        if (aoesLocked == false) {
+            foreach (var aoe in aoes)
+            {
+                aoe.Shape.Outline(Arena, aoe.Origin, aoe.Rotation, aoe.Color, 0.5f);
+            }
+        }
+
+        if (aoesLocked == true)
+        {
             return;
         }
 


### PR DESCRIPTION
converting the baiting cone to be only outline cone. when it locks, the background color will be fill back.
before:
<img width="447" height="399" alt="image" src="https://github.com/user-attachments/assets/d30850b4-df5e-45e8-925b-b29eab84d187" />

after:
<img width="377" height="410" alt="image" src="https://github.com/user-attachments/assets/b097ba45-1d76-492d-9a0e-a761dd5d2bd8" />


this is how it looks when the aoes are locked:
<img width="388" height="422" alt="image" src="https://github.com/user-attachments/assets/0968481c-9bcf-49dc-9a04-57b0a89bf42c" />
