### PR TITLE
DMU Phase 4 extra safeguard

### DIFF
--- a/BossMod/Modules/Dawntrail/Ultimate/DMU/DMUStates.cs
+++ b/BossMod/Modules/Dawntrail/Ultimate/DMU/DMUStates.cs
@@ -195,7 +195,9 @@ sealed class DMUStates : StateMachineBuilder {
             .ActivateOnExit<ForkedWater>()
             .ActivateOnExit<AccelerationBomb>();
 
-        ComponentCondition<ForkedWater>(id + 0x130, 8.4f, o => o.NumCasts >= 4, "Spreads + Stacks + Acceleration Bombs Resolve")
+        Condition(id + 0x130, 8.4f, () => Module.FindComponent<AccelerationBomb>()!.NumCasts >= 4 &&
+                                          Module.FindComponent<ForkedWater>()!.NumCasts >= 4,
+            "Spreads + Stacks + Acceleration Bombs Resolve")
             .DeactivateOnExit<ForkedWater>()
             .DeactivateOnExit<AccelerationBomb>()
             .ActivateOnEnter<LightningSafeSpots>()
@@ -226,7 +228,9 @@ sealed class DMUStates : StateMachineBuilder {
             .DeactivateOnExit<Inferno>()
             .DeactivateOnExit<InfernoBaits>();
 
-        ComponentCondition<ForkedWater>(id + 0x180, 4.2f, o => o.NumCasts >= 4, "Spreads + Stacks + Acceleration Bombs Resolve")
+        Condition(id + 0x180, 4.2f, () => Module.FindComponent<AccelerationBomb>()!.NumCasts >= 4 &&
+                                          Module.FindComponent<ForkedWater>()!.NumCasts >= 4,
+                "Spreads + Stacks + Acceleration Bombs Resolve")
             .DeactivateOnExit<ForkedWater>()
             .DeactivateOnExit<AccelerationBomb>()
             .ActivateOnEnter<BlizzardSafeSpots>();

--- a/BossMod/Modules/Dawntrail/Ultimate/DMU/Phase4.cs
+++ b/BossMod/Modules/Dawntrail/Ultimate/DMU/Phase4.cs
@@ -71,6 +71,7 @@ class GrandCrossOrder(BossModule module) : BossComponent(module) {
                 var expireAt = status.ExpireAt;
                 foreach (var entry in grandCross) {
                     entry.playerBuffs[slot].RemoveAll(b => b.buff == sid);
+                    Service.Logger.Info("Slot:" + slot + "Removed status effect: " + status.ID + " at world time: " + status.ExpireAt);
                 }
             }
         }
@@ -423,12 +424,29 @@ class ForkedWater(BossModule module) : Components.UniformStackSpread(module, 8.0
 }
 
 // 4x accleration bombs where two are from 1st set and the other 2 are from the 2nd set, so it can a mix of truth and lie
+// TODO move the StatusLose here for acceleration bomb to reset the playerStates since it follows the standard way to do it - wont change anything tho
+// TODO improve timeline for the mechanic make the component deactivate itself, can most likely do it base on the number of buffs gone by increasing it StatusLose
 class AccelerationBomb(BossModule module) : Components.StayMove(module) {
     private GrandCrossOrder? grandCrossOrder = module.FindComponent<GrandCrossOrder>();
+    public int NumCasts = 0;
+
+    public override void OnStatusLose(Actor actor, ref ActorStatus status) {
+        if (status.ID == (uint)SID.AccelerationBomb) {
+            var slot = Raid.FindSlot(actor.InstanceID);
+            if (slot >= 0) {
+                PlayerStates[slot] = default;
+                NumCasts++;
+
+                Service.Logger.Info($"Slot {slot} resetting");
+                Service.Logger.Info($"NumCasts {NumCasts}");
+            }
+        }
+    }
 
     public override void Update() {
         foreach (var (slot, _) in Raid.WithSlot()) {
             PlayerStates[slot] = default;
+            //Service.Logger.Info($"Slot {slot} resetting"); // todo debug - remove later
         }
 
         if (grandCrossOrder == null) {
@@ -442,10 +460,12 @@ class AccelerationBomb(BossModule module) : Components.StayMove(module) {
 
             if (tellingTruth == true) {
                 PlayerStates[slot] = new(Requirement.Stay, expireAt);
+                Service.Logger.Info($"Slot {slot} real bomb - stay still, which expires at {expireAt}"); // todo debug - remove later
             }
 
             if (tellingTruth == false) {
                 PlayerStates[slot] = new(Requirement.Move, expireAt);
+                Service.Logger.Info($"Slot {slot} fake bomb - move, which expires at {expireAt}"); // todo debug - remove later
             }
         }
     }


### PR DESCRIPTION
I don't think this will change anything, as it was already working fine. I have added an extra safeguard to ensure the playerState is set back to default when they lose the debuff. I think the bug report sent was just the fact that it was broken around a week ago.