### PR TITLE
Add support for buiding on mac

### DIFF
--- a/BossMod/BossModReborn.csproj
+++ b/BossMod/BossModReborn.csproj
@@ -44,6 +44,11 @@
     <DalamudLibPath>$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
     <SupportedOSPlatformVersion>10.0.26100.0</SupportedOSPlatformVersion>
   </PropertyGroup>
+    
+ <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Osx)))'">
+   <DalamudLibPath>$(DALAMUD_HOME)/</DalamudLibPath>  
+   <EnableWindowsTargeting>true</EnableWindowsTargeting>  
+ </PropertyGroup>   
 
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'">
     <DalamudLibPath>$(DALAMUD_HOME)/</DalamudLibPath>


### PR DESCRIPTION
Sometimes I want to lay in bed and write code with my laptop.

User will still need to set up their local environment to build but it is not so bad. Mostly just export the path to dalamud dependencies to the path as a local variable DALAMUD_HOME.

Something like this in your zshrc file and reload :
`export DALAMUD_HOME=<path to dalamud files on your system>/dalamud/Hooks/dev'

