### PR TITLE
Refine movement/casting logic and preset selection handling

### DIFF
--- a/BossMod/AI/AIBehaviour.cs
+++ b/BossMod/AI/AIBehaviour.cs
@@ -391,7 +391,9 @@ sealed class AIBehaviour(AIController ctrl, RotationModuleManager autorot, Prese
             var distSq = toDest.LengthSq();
             ctrl.NaviTargetPos = WorldState.CurrentTime >= _navStartTime ? _naviDecision.Destination : null;
             ctrl.NaviTargetVertical = master != player ? master.PosRot.Y : null;
-            ctrl.AllowInterruptingCastByMovement = player.CastInfo != null && _naviDecision.LeewaySeconds <= player.CastInfo.RemainingTime - 0.5d;
+            // if there's no active cast right now (e.g. it was just interrupted and an external plugin like RotationSolverReborn is about to re-queue it),
+            // there's nothing to protect - don't block forced movement, otherwise we can get stuck in an endless cast/interrupt loop without ever actually moving away from danger
+            ctrl.AllowInterruptingCastByMovement = player.CastInfo == null || _naviDecision.LeewaySeconds <= player.CastInfo.RemainingTime - 0.5d;
             ctrl.ForceCancelCast = false;
 
             //var cameraFacing = _ctrl.CameraFacing;

--- a/BossMod/Autorotation/MiscAI/NormalMovement.cs
+++ b/BossMod/Autorotation/MiscAI/NormalMovement.cs
@@ -81,7 +81,7 @@ public sealed class NormalMovement : RotationModule
         if (_decisionTask.IsCompletedSuccessfully)
         {
             _lastDecision = _decisionTask.Result;
-        }
+            }
 
         if (_decisionTask.IsCompleted)
         {
@@ -297,8 +297,12 @@ public sealed class NormalMovement : RotationModule
         }
         else
         {
-            // fine to move if we won't interrupt cast or only just started casting (or are explicitly allowed to)
-            var allowMovement = Player.CastInfo == null || Player.CastInfo.EventHappened || Player.CastInfo.ElapsedTime <= 1.0f || castStrategy is CastStrategy.DropMove or CastStrategy.DropInstants;
+            // fine to move if we won't interrupt cast (or are explicitly allowed to)
+            // note: do NOT unconditionally allow movement just because the cast barely started - that would defeat
+            // leeway/slidecasting entirely, since almost every cast starts with some non-urgent repositioning pending.
+            // the dedicated CastStrategy.Leeway handling below already forces movement (and cancels the cast) when
+            // there genuinely isn't enough leeway left to both finish the cast and reach the destination in time.
+            var allowMovement = Player.CastInfo == null || Player.CastInfo.EventHappened || castStrategy is CastStrategy.DropMove or CastStrategy.DropInstants;
             Hints.ForcedMovement = allowMovement ? dir.ToVec3(Player.PosRot.Y) : default;
         }
 

--- a/BossMod/Autorotation/UIPresetDatabaseEditor.cs
+++ b/BossMod/Autorotation/UIPresetDatabaseEditor.cs
@@ -95,8 +95,15 @@ public sealed class UIPresetDatabaseEditor(RotationDatabase rotationDB)
             """);
         ImGui.SameLine();
 
+        var selectedPresetList = _selectedPresetDefault ? PresetDB.DefaultPresets : PresetDB.UserPresets;
+        if (_selectedPresetIndex >= selectedPresetList.Count)
+        {
+            _selectedPresetIndex = -1;
+            _selectedPreset = null;
+        }
+
         ImGui.SetNextItemWidth(200);
-        using (var combo = ImRaii.Combo("Preset", _selectedPreset == null ? "" : _selectedPresetIndex < 0 ? "<new>" : (_selectedPresetDefault ? PresetDB.DefaultPresets : PresetDB.UserPresets)[_selectedPresetIndex].Name))
+        using (var combo = ImRaii.Combo("Preset", _selectedPreset == null ? "" : _selectedPresetIndex < 0 ? "<new>" : selectedPresetList[_selectedPresetIndex].Name))
         {
             if (combo)
             {

--- a/BossMod/Framework/IPCProvider.cs
+++ b/BossMod/Framework/IPCProvider.cs
@@ -179,7 +179,7 @@ sealed class IPCProvider : IDisposable
         Register("Hints.ForceCancelCastAI", () => ai.Controller.ForceCancelCast);
 
         Register("Movement.IsMoving", () => hints.ForcedMovement != null);
-
+        Register("Movement.IsMoveRequested", movement.IsMoveRequested);
         Register("Hints.ForbiddenZonesCount", () => hints.ForbiddenZones.Count);
         Register("Hints.ForbiddenZonesNextActivation", () => hints.ForbiddenZones.Count == 0 ? float.MaxValue : (float)(hints.ForbiddenZones[0].activation - DateTime.Now).TotalSeconds);
         Register("Hints.ArenaCenter", () => new Vector2(hints.PathfindMapCenter.X, hints.PathfindMapCenter.Z));


### PR DESCRIPTION
- Update AI behavior to allow movement only when not casting, preventing cast/interrupt loops with plugins.
- Refine NormalMovement to preserve leeway/slidecasting by not always allowing movement at cast start.
- Fix UIPresetDatabaseEditor preset selection to avoid out-of-range errors and refactor to use a unified preset list.
- Add IPC registration for "Movement.IsMoveRequested" to expose movement request state.