### PR TITLE
Custom arena bounds and shapes.cs debug graphics overlay

### DIFF
--- a/BossMod/Debug/DebugGraphics.cs
+++ b/BossMod/Debug/DebugGraphics.cs
@@ -1,6 +1,7 @@
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility.Raii;
 using FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
+using Windows.UI.Input;
 
 namespace BossMod;
 
@@ -15,13 +16,36 @@ sealed class DebugGraphics
 
     private bool _showGraphicsLeafCharactersOnly = true;
     private readonly Dictionary<IntPtr, WatchedRenderObject> _watchedRenderObjects = [];
-    private bool _overlayCircle;
+    private bool _overlayCircle; // enables circular polar grid.
+    private bool _overlayAllCustom; // The switch for drawing custom shapes on arena.
     private Vector2 _overlayCenter = new(100, 100);
     private Vector2 _overlayStep = new(2, 2);
     private Vector2 _overlayMaxOffset = new(20, 20);
-    private Angle _overlayRotation = new(0);
+    private Angle _overlayRotation = new(0); // Rotates the rectangle grid.
+    private Angle _angleVisRotation = new(0); // Rotates the angle visualizer arm.
+    private float _angVisRotDegrees = 0;
+    private Vector2 _placedCenter = new(100, 100);
     private float _placedOffset = 4.0f; // for placing a drawn shape on overlay.
     private float _placedWidth = 0.5f; // width of drawn shape on overlay. Used  as radius in circles.
+    private float _placedHeight = 0.5f;
+    private Angle _placedRotation = new(0);
+    private Angle _placedHalfAngle = new(0);
+    private Vector3 _placedVec3 = Vector3.Zero;
+    private Vector3 _placedOffsetLocation = Vector3.Zero;
+    private int _placedEdges = 7;
+
+    private readonly string[] _shapeTemplates =
+    [
+        "No Shape Template Selected", "Circle", "Rectangle", "Donut", "Cross", "DonutSegmentHA", "Ellipse", "Capsule"
+    ]; // Need to implement shape functions if new options added.
+
+    private int _selectedShapeIndex = -1;
+    private List<Shape> _unionShapes = [];
+    private List<Shape> _diffShapes = [];
+    private List<Shape> _additionalShapes = [];
+    private int _selectedUnionShapesIdx = -1;
+    private int _selectedDiffShapesIdx = -1;
+    private int _selectedAdditionalShapesIdx = -1;
 
     public unsafe void DrawSceneTree()
     {
@@ -39,8 +63,10 @@ sealed class DebugGraphics
         do
         {
             var nodeText = $"{SceneNodeText(o)}###{(IntPtr)o}";
-            var nodeFlags = (o->ChildObject != null ? ImGuiTreeNodeFlags.None : ImGuiTreeNodeFlags.Leaf) | ImGuiTreeNodeFlags.OpenOnArrow;
-            var showNode = !_showGraphicsLeafCharactersOnly || o->ChildObject != null || o->GetObjectType() == ObjectType.CharacterBase;
+            var nodeFlags = (o->ChildObject != null ? ImGuiTreeNodeFlags.None : ImGuiTreeNodeFlags.Leaf) |
+                            ImGuiTreeNodeFlags.OpenOnArrow;
+            var showNode = !_showGraphicsLeafCharactersOnly || o->ChildObject != null ||
+                           o->GetObjectType() == ObjectType.CharacterBase;
             if (showNode && ImGui.TreeNodeEx(nodeText, nodeFlags))
             {
                 if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
@@ -58,6 +84,7 @@ sealed class DebugGraphics
                                 size = 0x1C8;
                                 break;
                         }
+
                         WatchObject(o, size);
                     }
                     else
@@ -73,9 +100,9 @@ sealed class DebugGraphics
 
                 ImGui.TreePop();
             }
+
             o = o->NextSiblingObject;
-        }
-        while (o != start);
+        } while (o != start);
     }
 
     public unsafe void DrawWatchedMods()
@@ -136,6 +163,7 @@ sealed class DebugGraphics
             ImGui.TableNextColumn();
             DrawMods(v.Value);
         }
+
         ImGui.EndTable();
 
         foreach (var v in _watchedRenderObjects)
@@ -178,8 +206,7 @@ sealed class DebugGraphics
             }
 
             o = o->NextSiblingObject;
-        }
-        while (o != start);
+        } while (o != start);
     }
 
     private unsafe void UpdateWatchedMod(void* o, WatchedRenderObject w)
@@ -196,6 +223,7 @@ sealed class DebugGraphics
                 w.Modifications.InsertRange(i, mods);
                 i += mods.Count;
             }
+
             start = nextStart;
         }
 
@@ -239,6 +267,7 @@ sealed class DebugGraphics
                 ++start;
             }
         }
+
         return res;
     }
 
@@ -251,6 +280,7 @@ sealed class DebugGraphics
             DrawHexString(w, ref start, end, Colors.PlayerGeneric, sb);
             DrawHexString(w, ref start, nextStart, Colors.TextColor3, sb);
         }
+
         sb.Clear();
         DrawHexString(w, ref start, w.Data.Count, Colors.PlayerGeneric, sb);
     }
@@ -274,6 +304,7 @@ sealed class DebugGraphics
                 sb.Clear();
             }
         }
+
         ImGui.TextUnformatted(sb.ToString());
         ImGui.SameLine();
         ImGui.PopStyleColor();
@@ -351,13 +382,16 @@ sealed class DebugGraphics
         ImGui.TableNextColumn();
         ImGui.TextUnformatted("Near/far/aspect");
         ImGui.TableNextColumn();
-        ImGui.TextUnformatted($"{camera->RenderCamera->NearPlane} / {camera->RenderCamera->FarPlane} / {camera->RenderCamera->AspectRatio}");
+        ImGui.TextUnformatted(
+            $"{camera->RenderCamera->NearPlane} / {camera->RenderCamera->FarPlane} / {camera->RenderCamera->AspectRatio}");
 
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
         ImGui.TextUnformatted("Projection flags");
         ImGui.TableNextColumn();
-        if (ImGui.Button(camera->RenderCamera->IsOrtho ? $"ortho ({camera->RenderCamera->OrthoHeight})" : "perspective"))
+        if (ImGui.Button(camera->RenderCamera->IsOrtho
+                ? $"ortho ({camera->RenderCamera->OrthoHeight})"
+                : "perspective"))
         {
             camera->RenderCamera->IsOrtho ^= true;
         }
@@ -423,17 +457,24 @@ sealed class DebugGraphics
         {
             if (Service.ObjectTable.LocalPlayer != null)
             {
-                _overlayCenter.X = Service.ObjectTable.LocalPlayer.Position.X;
-                _overlayCenter.Y = Service.ObjectTable.LocalPlayer.Position.Z;
+                var newX = Service.ObjectTable.LocalPlayer.Position.X;
+                var newY = Service.ObjectTable.LocalPlayer.Position.Z;
+
+                _overlayCenter.X = newX;
+                _overlayCenter.Y = newY;
+                // adjust the shape template center also so that everything is aligned
+                _placedCenter.X = newX;
+                _placedCenter.Y = newY;
             }
         }
+
         ImGui.DragFloat2("Step", ref _overlayStep, 0.25f, 1, 10);
         ImGui.DragFloat2("Max offset", ref _overlayMaxOffset);
 
         var rotationDegrees = _overlayRotation.Deg;
-        ImGui.SliderFloat("Rotation (Degrees)", ref rotationDegrees, -180, 180, "%.3f");
+        ImGui.SliderFloat("Rotation (Degrees) ## Grid overlay rotation", ref rotationDegrees, -180, 180, "%.2f");
         ImGui.SameLine();
-        ImGui.InputFloat("##RotationInput", ref rotationDegrees, 0.1f, 1, "%.3f");
+        ImGui.InputFloat("##RotationInput", ref rotationDegrees, 0.1f, 1, "%.2f");
         _overlayRotation = new Angle(rotationDegrees * Angle.DegToRad);
 
         // instead of dividing by zero just provide the value.
@@ -442,7 +483,9 @@ sealed class DebugGraphics
         var y = Service.ObjectTable.LocalPlayer!.Position.Y;
 
         var rotationMatrix = Matrix3x2.CreateRotation(-_overlayRotation.Rad);
-        Vector2 TransformPoint(Vector2 point) => Vector2.Transform(point - _overlayCenter, rotationMatrix) + _overlayCenter;
+
+        Vector2 TransformPoint(Vector2 point) =>
+            Vector2.Transform(point - _overlayCenter, rotationMatrix) + _overlayCenter;
 
         if (_overlayCircle)
         {
@@ -451,23 +494,12 @@ sealed class DebugGraphics
             {
                 Camera.Instance.DrawWorldCircle(center, ir * _overlayStep.X, Colors.PC);
             }
+
             for (var ia = 0; ia < 8; ++ia)
             {
                 var offset = ((ia * 22.5f.Degrees()).ToDirection() * _overlayMaxOffset.X).ToVec3();
                 Camera.Instance.DrawWorldLine(center - offset, center + offset, Colors.PC);
             }
-            // Angle Visualizer for circular overlay. Show an angle with vec 3 coordinates.
-            // This is drawing the line to move around and show the angle we are at.
-            // Use the degrees slider to move the angle visualizer around the circle.
-            var pickOffset = (_overlayRotation.ToDirection() * (_overlayMaxOffset.X)).ToVec3();
-            var outsideVec3 = center + pickOffset;
-            Camera.Instance.DrawWorldLine(center, center + pickOffset, Colors.Danger, thickness: 3);
-
-            // Show the coordinates for the outside edge of the polar grid where end of visualizer arm is.
-            ImGui.TextUnformatted("Vec3 coordinates in the center of angle visualizer circle: ");
-            ImGui.TextUnformatted(Utils.Vec3String(outsideVec3));
-
-            InsertShapesIntoOverlay();
         }
         else
         {
@@ -478,6 +510,7 @@ sealed class DebugGraphics
                 var end = TransformPoint(new Vector2(x, _overlayCenter.Y + _overlayMaxOffset.Y));
                 Camera.Instance.DrawWorldLine(new(start.X, y, start.Y), new(end.X, y, end.Y), Colors.PC);
             }
+
             for (var iz = -mz; iz <= mz; ++iz)
             {
                 var z = _overlayCenter.Y + iz * _overlayStep.Y;
@@ -486,45 +519,658 @@ sealed class DebugGraphics
                 Camera.Instance.DrawWorldLine(new(start.X, y, start.Y), new(end.X, y, end.Y), Colors.PC);
             }
         }
+
+        ImGui.NewLine();
+        ImGui.Separator();
+        ImGui.Spacing();
+        /*
+         * Dropdown box that determines what shape template is being placed, circle, rectangle, etc.
+         * Also has a 'no shape selected' option for putting the angle visualizer arm and shape template to invisible.
+         */
+        ImGui.Combo("Select Shape Template", ref _selectedShapeIndex, _shapeTemplates, _shapeTemplates.Length);
+        if (_selectedShapeIndex > -0 && _selectedShapeIndex < _shapeTemplates.Length)
+            InsertShapesIntoOverlay(_shapeTemplates[_selectedShapeIndex]);
+
+        ArenaBoundsShapesTripleListTable();
+        ImGui.NewLine();
+    }
+
+    /*
+     * Draw the angle visualizer arm. An arm that rotates around center point of grid.
+     * Used for seeing angles and placing selected shapes in overlay.
+     */
+    public void AngleVisualizer()
+    {
+        // These two get duplicated often. Probably should be higher in the hierarchy
+        var y = Service.ObjectTable.LocalPlayer!.Position.Y;
+        var center = new Vector3(_overlayCenter.X, y, _overlayCenter.Y);
+
+        _angVisRotDegrees = _angleVisRotation.Deg;
+        ImGui.SliderFloat("Arm Rotation (Degrees) ## Angle visualizer rotation", ref _angVisRotDegrees, -180, 180,
+            "%.2f");
+
+        /* Angle Visualizer for circular overlay. Show an angle with vec 3 coordinates.
+         * This is drawing the line to move around and show the angle we are at.
+         * Use the degrees slider to move the angle visualizer around the circle.
+         */
+        var pickOffset = (_angleVisRotation.ToDirection() * (_overlayMaxOffset.X)).ToVec3();
+        var outsideVec3 = center + pickOffset;
+        Camera.Instance!.DrawWorldLine(center, outsideVec3, Colors.Danger, thickness: 3);
+
+        // Show the coordinates where the outside point of the visualizer arm is.
+        ImGui.TextUnformatted("Vec3 coordinates at the end of angle visualizer arm : ");
+        ImGui.TextUnformatted(Utils.Vec3String(outsideVec3));
     }
 
     // Create a method that will let you grab a shape and draw it in the overlay.
     // It should create boilerplate code for creating that shape in radar.
-    public void InsertShapesIntoOverlay()
+    public void InsertShapesIntoOverlay(string shape)
     {
-        var origin = new Vector3(_overlayCenter.X, Service.ObjectTable.LocalPlayer!.Position.Y, _overlayCenter.Y);
+        AngleVisualizer();
+        // TODO figure out how to adjust the location by manual position entry or click on screen
+        var y = Service.ObjectTable.LocalPlayer!.Position.Y;
+        var origin = new Vector3(_overlayCenter.X, y, _overlayCenter.Y);
+        ImGui.SliderFloat($"Placed {shape.ToLower()} offset", ref _placedOffset, 0f, 30f, "%.2f");
+        _placedOffsetLocation = (_angleVisRotation.ToDirection() * _placedOffset).ToVec3();
+        _placedVec3 = origin + _placedOffsetLocation;
+        _placedCenter.X = _placedVec3.X;
+        _placedCenter.Y = _placedVec3.Z;
 
-        // This will exist even if a shape isn't being drawn. Maybe have it only appear when a shape is up.
-        ImGui.SliderFloat("Placed shape offset", ref _placedOffset, 0f, 30f, "%.3f");
-        var placedOffsetLocation = (_overlayRotation.ToDirection() * _placedOffset).ToVec3();
+        // Pattern match the shapes in order to call the correct ui features.
+        // Should show sliders for width/height/rotation based on Shape.cs params.
+        // Also define StringBuilder for each shape so that code generation can work
 
-        // Sometimes shapes can be larger than arena.
-        if (ImGui.CollapsingHeader("Add Circle Shape"))
+        /* TODO probably worth adding an option to enter coordinates for a shape directly instead of trying to
+         * finesse it using the arm. Like if you get coordinates for something from logs, you could just enter and test
+         * it matches. Will need a string parsing engine for that.
+         */
+        switch (shape)
         {
-            ImGui.SliderFloat("Placed circle radius", ref _placedWidth, 0, _overlayMaxOffset.X + 10, "%.3f");
-            var placedVec3 = origin + placedOffsetLocation;
-            Camera.Instance!.DrawWorldCircle(placedVec3, _placedWidth, Colors.Danger, thickness: 3);
+            case "Circle":
+                PlacedRadiusSlider(shape);
+                // TODO try sending to DrawWorldShapes to see if it looks janky like customBounds does
+                Camera.Instance!.DrawWorldCircle(_placedVec3, _placedWidth, Colors.Danger, thickness: 3);
+                var placedCirc = new Circle(new WPos(_placedCenter.X, _placedCenter.Y), _placedWidth);
+                // Show the coordinates for the center of the placed shape
+                PlaceCoordinates(_placedVec3, shape);
+                AddShapeButtons(placedCirc);
+                // Show sample generated code snippet for shape above code export button.
+                ImGui.TextUnformatted(ShapeString(placedCirc).ToString());
+                ShapeStringButton(placedCirc);
+                break;
+            case "Rectangle":
+                PlacedHalfWidthSlider(shape);
+                PlacedHalfHeightSlider(shape);
+                // Rotation slider for the shape template
+                PlacedRotationSlider(shape);
+                var placedRect = new Rectangle(new WPos(_placedCenter.X, _placedCenter.Y), _placedWidth, _placedHeight,
+                    _placedRotation);
+                Camera.Instance!.DrawWorldRectangle(_placedVec3, placedRect, Colors.Danger, thickness: 3);
+                // Show the coordinates for the center of the placed shape
+                PlaceCoordinates(_placedVec3, shape);
+                AddShapeButtons(placedRect);
+                // Show sample generated code snippet for shape above code export button.
+                ImGui.TextUnformatted(ShapeString(placedRect).ToString());
+                ShapeStringButton(placedRect);
+                break;
+            case "Donut":
+                PlacedInnerRadiusSlider(shape);
+                PlacedOuterRadiusSlider(shape);
+                var placedDonut = new Donut(new WPos(_placedCenter.X, _placedCenter.Y), _placedWidth, _placedHeight);
+                Camera.Instance!.DrawWorldShape(_placedVec3, placedDonut, Colors.Danger, thickness: 3);
+                // Show the coordinates for the center of the placed shape
+                PlaceCoordinates(_placedVec3, shape);
+                AddShapeButtons(placedDonut);
+                // Show sample generated code snippet for shape above code export button.
+                ImGui.TextUnformatted(ShapeString(placedDonut).ToString());
+                ShapeStringButton(placedDonut);
+                break;
+            case "Cross":
+                PlacedLengthSlider(shape);
+                PlacedHalfWidthSlider(shape);
+                PlacedRotationSlider(shape);
+                var placedCross = new Cross(new WPos(_placedCenter.X, _placedCenter.Y), _placedHeight, _placedWidth,
+                    _placedRotation);
+                Camera.Instance!.DrawWorldShape(_placedVec3, placedCross, Colors.Danger, thickness: 3);
+                // Show the coordinates for the center of the placed shape
+                PlaceCoordinates(_placedVec3, shape);
+                AddShapeButtons(placedCross);
+                // Show sample generated code snippet for shape above code export button.
+                ImGui.TextUnformatted(ShapeString(placedCross).ToString());
+                ShapeStringButton(placedCross);
+                break;
+            case "DonutSegmentHA":
+                PlacedInnerRadiusSlider(shape);
+                PlacedOuterRadiusSlider(shape);
+                PlacedRotationSlider(shape);
+                PlacedHalfAngleSlider(shape);
+                var placedDonutHA = new DonutSegmentHA(new WPos(_placedCenter.X, _placedCenter.Y), _placedHeight,
+                    _placedWidth, _placedRotation, HalfAngle: _placedHalfAngle);
+                Camera.Instance!.DrawWorldShape(_placedVec3, placedDonutHA, Colors.Danger, thickness: 3);
+                // Show the coordinates for the center of the placed shape
+                PlaceCoordinates(_placedVec3, shape);
+                AddShapeButtons(placedDonutHA);
+                // Show sample generated code snippet for shape above code export button.
+                ImGui.TextUnformatted(ShapeString(placedDonutHA).ToString());
+                ShapeStringButton(placedDonutHA);
+                break;
+            case "Ellipse":
+                PlacedHalfWidthSlider(shape);
+                PlacedHalfHeightSlider(shape);
+                PlacedEdgesInput(shape);
+                PlacedRotationSlider(shape);
+                var placedEllipse = new Ellipse(new WPos(_placedCenter.X, _placedCenter.Y), _placedWidth, _placedHeight,
+                    _placedEdges, _placedRotation);
+                Camera.Instance!.DrawWorldShape(_placedVec3, placedEllipse, Colors.Danger, thickness: 3);
+                // Show the coordinates for the center of the placed shape
+                PlaceCoordinates(_placedVec3, shape);
+                AddShapeButtons(placedEllipse);
+                // Show sample generated code snippet for shape above code export button.
+                ImGui.TextUnformatted(ShapeString(placedEllipse).ToString());
+                ShapeStringButton(placedEllipse);
+                break;
+            case "Capsule":
+                PlacedHalfHeightSlider(shape);
+                PlacedHalfWidthSlider(shape);
+                PlacedEdgesInput(shape);
+                PlacedRotationSlider(shape);
+                var placedCapsule = new Capsule(new WPos(_placedVec3.X, _placedVec3.Z), halfHeight: _placedHeight,
+                    halfWidth: _placedWidth, edges: _placedEdges, rotation: _placedRotation);
+                Camera.Instance!.DrawWorldShape(_placedVec3, placedCapsule, Colors.Danger, thickness: 3);
+                // Show the coordinates for the center of the placed shape
+                PlaceCoordinates(_placedVec3, shape);
+                AddShapeButtons(placedCapsule);
+                // Show sample generated code snippet for shape above code export button.
+                ImGui.TextUnformatted(ShapeString(placedCapsule).ToString());
+                ShapeStringButton(placedCapsule);
+                break;
+            default:
+                break;
+        }
 
-            // Show the coordinates for the center of the placed shape
-            ImGui.TextUnformatted("Vec3 coordinates in the center of placed shape: ");
-            ImGui.TextUnformatted(Utils.Vec3String(placedVec3));
+        ;
+    }
 
-            // TODO generalize to other shapes later. For now just a circle.
-            CircleString(placedVec3, _placedWidth);
+    public void PlaceCoordinates(Vector3 placedCoords, string shape)
+    {
+        // Show the coordinates for the center of the placed shape
+        ImGui.TextUnformatted($"Coordinates in the center of placed {shape}: ");
+        // Sets a minimum of 0.0f and a maximum of 100.0f for both X and Y
+        // Originally wanted to be able to just enter coordinates and have template jump, but it is difficult because
+        // location is tied to angle visualizer arm and offset variables also.
+        ImGui.DragFloat2($"Center of Placed {shape}", ref _placedCenter, 0.25f, vMin: -(_overlayMaxOffset.X + 10),
+            vMax: (_overlayMaxOffset.X + 10));
+        _angleVisRotation = new Angle(_angVisRotDegrees * Angle.DegToRad);
+    }
+
+    ///
+    /// Various widgets for the different parameters of shapes.
+    /// Buttons and sliders for things like radius, half height, half width, etc.
+    ///
+    public void PlacedRotationSlider(string shape)
+    {
+        var placedRotationDegrees = _placedRotation.Deg;
+        ImGui.SliderFloat($"Placed {shape.ToLower()} rotation (Degrees) ## Rotation for template shape",
+            ref placedRotationDegrees, -180, 180, "%.2f");
+        _placedRotation = new Angle(placedRotationDegrees * Angle.DegToRad);
+    }
+
+    public void PlacedHalfAngleSlider(string shape)
+    {
+        var placedHalfAngleDegrees = _placedHalfAngle.Deg;
+        ImGui.SliderFloat($"Placed {shape.ToLower()} half angle (Degrees) ## Half angle slider",
+            ref placedHalfAngleDegrees, -180, 180, "%.2f");
+        _placedHalfAngle = new Angle(placedHalfAngleDegrees * Angle.DegToRad);
+    }
+
+    public void PlacedHalfWidthSlider(string shape)
+    {
+        ImGui.SliderFloat($"Placed {shape.ToLower()} half width", ref _placedWidth, 0, _overlayMaxOffset.X + 10,
+            "%.2f");
+    }
+
+    public void PlacedHalfHeightSlider(string shape)
+    {
+        ImGui.SliderFloat($"Placed {shape.ToLower()} half height", ref _placedHeight, 0, _overlayMaxOffset.Y + 10,
+            "%.2f");
+    }
+
+    public void PlacedLengthSlider(string shape)
+    {
+        ImGui.SliderFloat($"Placed {shape.ToLower()} length", ref _placedHeight, 0, _overlayMaxOffset.Y + 10,
+            "%.2f");
+    }
+
+    public void PlacedRadiusSlider(string shape)
+    {
+        ImGui.SliderFloat($"Placed {shape.ToLower()} radius", ref _placedWidth, 0, _overlayMaxOffset.X + 10, "%.2f");
+    }
+
+    public void PlacedInnerRadiusSlider(string shape)
+    {
+        ImGui.SliderFloat($"Placed {shape.ToLower()} inner radius", ref _placedWidth, 0, _overlayMaxOffset.X + 10,
+            "%.2f");
+    }
+
+    public void PlacedOuterRadiusSlider(string shape)
+    {
+        ImGui.SliderFloat($"Placed {shape.ToLower()} outer radius", ref _placedHeight, 0, _overlayMaxOffset.X + 10,
+            "%.2f");
+    }
+
+    public void PlacedEdgesInput(string shape)
+    {
+        // Minus Button
+        if (ImGui.Button(" - ##minus_int"))
+        {
+            _placedEdges -= 1;
+        }
+
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(100);
+        ImGui.InputInt("Number of edges ", ref _placedEdges);
+        ImGui.SameLine();
+
+        // Plus Button
+        if (ImGui.Button(" + ##plus_int"))
+        {
+            _placedEdges += 1;
         }
     }
 
-    // Outputs the c# code for drawing a circle shape in BossModule.
-    public void CircleString(Vector3 placed, float radius)
+    /// StringBuilder methods for generating one off Shape code snippets.
+    /// outputs c# code. May want to clean up the coordinates and rotations for accuracy after output.
+    /// It will only be as accurate as the placed shape template placement.
+    /// Semicolons intentionally left off the end for use in generating code snippets for larger
+    /// lists of shapes.
+    ///
+    /// Define a function for each shape that can be drawn.
+    public StringBuilder CircleString(Circle circ)
     {
-        var exportedCircle = new StringBuilder($"new Circle(new WPos({placed.X}f, {placed.Z}f), {radius}f);");
-
+        var exportedCircle =
+            new StringBuilder($"new Circle(new WPos({circ.Center.X:F2}f, {circ.Center.Z:F2}f), {circ.Radius:F2}f)");
         ImGui.TextUnformatted(exportedCircle.ToString());
 
         if (ImGui.Button("Copy Circle To Clipboard"))
         {
             ImGui.SetClipboardText(exportedCircle.ToString());
         }
+        return exportedCircle;
+    }
+
+    public StringBuilder RectangleString(Rectangle rect)
+    {
+        var exportedRectangle =
+            new StringBuilder(
+                $"new Rectangle(new WPos({rect.Center.X:F2}f, {rect.Center.Z:F2}f), {rect.HalfWidth:F2}f, {rect.HalfHeight:F2}f, {rect.Rotation}f.Degrees()");
+        ImGui.TextUnformatted(exportedRectangle.ToString());
+
+        return exportedRectangle;
+    }
+
+    // Generate a code snippet for a single shape. X and Z coordinates are rounded from 3 decimal places down to 2.
+    public StringBuilder ShapeString(Shape shape)
+    {
+        StringBuilder exportedShape = new StringBuilder();
+        switch (shape)
+        {
+            case Circle c:
+                exportedShape.Append(
+                    $"new {shape.GetType().Name}(new WPos({c.Center.X:F2}f, {c.Center.Z:F2}f), {c.Radius:F2}f)");
+                break;
+            case Rectangle r:
+                exportedShape.Append(
+                    $"new {shape.GetType().Name}(new WPos({r.Center.X:F2}f, {r.Center.Z:F2}f), {r.HalfWidth:F2}f, {r.HalfHeight:F2}f, {r.Rotation}f.Degrees())");
+                break;
+            case Donut d:
+                exportedShape.Append(
+                    $"new {shape.GetType().Name}(new WPos({d.Center.X:F2}f, {d.Center.Z:F2}f), {d.InnerRadius:F2}f, {d.OuterRadius:F2}f)");
+                break;
+            case Cross cross:
+                exportedShape.Append(
+                    $"new {shape.GetType().Name}(new WPos({cross.Center.X:F2}f, {cross.Center.Z:F2}f), {cross.Length:F2}f, {cross.HalfWidth:F2}f, {cross.Rotation:F2}f.Degrees())");
+                break;
+            case DonutSegmentHA donutSegmentHA:
+                exportedShape.Append(
+                    $"new {shape.GetType().Name}(new WPos({donutSegmentHA.Center.X:F2}f, {donutSegmentHA.Center.Z:F2}f), {donutSegmentHA.InnerRadius:F2}f, {donutSegmentHA.OuterRadius:F2}f, {donutSegmentHA.EndAngle:F2}f.Degrees(), {donutSegmentHA.EndAngle}f.Degrees())");
+                break;
+            case Ellipse ellipse:
+                exportedShape.Append(
+                    $"new {shape.GetType().Name}(new WPos({ellipse.Center.X:F2}f, {ellipse.Center.Z:F2}f), {ellipse.HalfWidth:F2}f, {ellipse.HalfHeight:F2}f, {ellipse.Edges}, {ellipse.Rotation}f.Degrees())");
+                break;
+            case Capsule capsule:
+                exportedShape.Append(
+                    $"new {shape.GetType().Name}(new WPos({capsule.Center.X:F2}f, {capsule.Center.Z:F2}f), {capsule.HalfHeight:F2}f, {capsule.HalfWidth:F2}f, {capsule.Edges}, {capsule.Rotation}f.Degrees())");
+                break;
+            default:
+                break;
+        }
+
+        ;
+        return exportedShape;
+    }
+
+    public void ShapeStringButton(Shape shape)
+    {
+        if (ImGui.Button($"Copy {shape.GetType().Name} To Clipboard"))
+        {
+            ImGui.SetClipboardText(ShapeString(shape).ToString());
+        }
+    }
+
+    public StringBuilder ListString(List<Shape> shapes, string listName)
+    {
+        var exportedList = new StringBuilder($"List<Shape>  {listName} = [");
+
+        // TODO iterate through list and call StringBuilder function based off Shape Type pattern match.
+        for (int i = 0; i < shapes.Count; i++)
+        {
+            // Pattern matching Shape type lets us cast to the shape.
+            var shape = shapes[i];
+            if (i == 0)
+                exportedList.Append(ShapeString(shape));
+            else
+            {
+                exportedList.Append($", {ShapeString(shape)}");
+            }
+        }
+        exportedList.Append("];");
+
+        return exportedList;
+    }
+
+    // Export a generated code snippet for a List<Shape> to clipboard.
+    public void ListStringButton(List<Shape> shapes, string listName)
+    {
+        if (ImGui.Button($"Copy {listName} To Clipboard"))
+        {
+            ImGui.SetClipboardText(ListString(shapes, listName).ToString());
+        }
+    }
+
+    public void AddShapeButtons(Shape addShape)
+    {
+        Type typeInfo = addShape.GetType();
+        string shapeName = typeInfo.Name;
+        // Only add the shape if it does not already exist in one of the lists.
+        bool shapeExists = (_unionShapes.Exists(shape => shape.ToString() == addShape.ToString()) ||
+                            _diffShapes.Exists(shape => shape.ToString() == addShape.ToString()) ||
+                            _additionalShapes.Exists(shape => shape.ToString() == addShape.ToString()));
+
+        if (ImGui.Button($"Add {shapeName} To UnionShapes[]"))
+        {
+            if (!shapeExists)
+                _unionShapes.Add(addShape);
+        }
+
+        ImGui.SameLine();
+        if (ImGui.Button($"Add {shapeName} To DiffShapes[]"))
+        {
+            if (!shapeExists)
+                _diffShapes.Add(addShape);
+        }
+
+        ImGui.SameLine();
+        if (ImGui.Button($"Add {shapeName} To AdditionalShapes[]"))
+        {
+            if (!shapeExists)
+                _additionalShapes.Add(addShape);
+        }
+    }
+
+    // TODO might be worth having an import box that can parse a custom shape or custom arena bound for visually checking existing code.
+    public void DrawCameraShapes()
+    {
+        // TODO add checkboxes for additional arena bounds custom options. maybe a drop box for the colors.
+        ArenaBoundsCustom arena = new([.. _unionShapes], [.. _diffShapes], [.. _additionalShapes]);
+
+        if (_overlayAllCustom)
+        {
+            // DrawWorldPoly for drawing the arena bounds or a custom polygon as needed.
+            var center = new Vector3(arena.Center.X, Service.ObjectTable.LocalPlayer!.Position.Y, arena.Center.Z);
+            Camera.Instance!.DrawWorldPoly(center, arena.Polygon, Colors.Border, 3f);
+        }
+    }
+
+    // Draw a single shape
+    public void DrawCameraShape(WPos center, Shape shape, uint color, float thickness)
+    {
+        // TODO add checkboxes for additional arena bounds custom options. maybe a drop box for the colors.
+        var centerVec3 = new Vector3(center.X, Service.ObjectTable.LocalPlayer!.Position.Y, center.Z);
+        Camera.Instance!.DrawWorldShape(centerVec3, shape, color, thickness);
+    }
+
+    /* This table represents the visual arrays of arena bounds custom.
+     * Has a list for each array and what items are in them.
+     * Has buttons to allow moving and removing shapes from between the different lists.
+     * Only appears once a single shape has been added. Not  all lists need shapes.
+     */
+    public void ArenaBoundsShapesTripleListTable()
+    {
+        if (_unionShapes.Count > 0 || _diffShapes.Count > 0 || _additionalShapes.Count > 0)
+        {
+            ImGui.Checkbox("Draw Shapes on Arena", ref _overlayAllCustom);
+            // Draw all custom polygon arena bounds in the world.
+            DrawCameraShapes();
+
+            ImGui.BeginTable("triple_list_table", 5, ImGuiTableFlags.SizingFixedFit);
+            ImGui.TableSetupColumn("UnionShapes", ImGuiTableColumnFlags.WidthStretch, 200f);
+            ImGui.TableSetupColumn("Buttons1", ImGuiTableColumnFlags.WidthFixed, 50f);
+            ImGui.TableSetupColumn("DiffShapes", ImGuiTableColumnFlags.WidthStretch, 200f);
+            ImGui.TableSetupColumn("Buttons2", ImGuiTableColumnFlags.WidthFixed, 50f);
+            ImGui.TableSetupColumn("AdditionalShapes", ImGuiTableColumnFlags.WidthStretch, 200f);
+            ImGui.TableNextRow();
+
+            // Column 1: _unionShapes List
+            ImGui.TableSetColumnIndex(0);
+            ImGui.Text("UnionShapes");
+            ImGui.BeginChild("UnionRegion", new System.Numerics.Vector2(0, 100), true);
+            for (int i = 0; i < _unionShapes.Count; i++)
+            {
+                bool isUnionSelected = (_selectedUnionShapesIdx == i);
+                if (ImGui.Selectable(_unionShapes[i].ToString(), isUnionSelected))
+                {
+                    _selectedUnionShapesIdx = i;
+                    // Highlight a selected shape briefly so we can visually see which one we are focused on.
+                    var selectedShape = _unionShapes[_selectedUnionShapesIdx];
+                    // Briefly highlight selected shape in list so we can visually tell where things are.
+                    HighlightSelection(selectedShape);
+                }
+            }
+
+            ImGui.EndChild();
+
+            // Column 2: Transfer Buttons
+            ImGui.TableSetColumnIndex(1);
+            ImGui.Dummy(new System.Numerics.Vector2(0, 40)); // spacing
+            if (ImGui.Button(" > ## column 2 move right") && _selectedUnionShapesIdx >= 0 &&
+                _selectedUnionShapesIdx < _unionShapes.Count)
+            {
+                _diffShapes.Add(_unionShapes[_selectedUnionShapesIdx]);
+                _unionShapes.RemoveAt(_selectedUnionShapesIdx);
+                _selectedUnionShapesIdx = -1;
+            }
+
+            if (ImGui.Button(" < ## column 2 move left") && _selectedDiffShapesIdx >= 0 &&
+                _selectedDiffShapesIdx < _diffShapes.Count)
+            {
+                _unionShapes.Add(_diffShapes[_selectedDiffShapesIdx]);
+                _diffShapes.RemoveAt(_selectedDiffShapesIdx);
+                _selectedDiffShapesIdx = -1;
+            }
+
+            // Column 3: _diffShapes List
+            ImGui.TableSetColumnIndex(2);
+            ImGui.Text("DiffShapes");
+            ImGui.BeginChild("DiffRegion", new System.Numerics.Vector2(0, 100), true);
+            for (int i = 0; i < _diffShapes.Count; i++)
+            {
+                bool isSelected = (_selectedDiffShapesIdx == i);
+                if (ImGui.Selectable(_diffShapes[i].ToString(), isSelected))
+                {
+                    _selectedDiffShapesIdx = i;
+                    // Highlight a selected shape briefly so we can visually see which one we are focused on.
+                    var selectedShape = _diffShapes[_selectedDiffShapesIdx];
+                    // Briefly highlight selected shape in list so we can visually tell where things are.
+                    // Can tap the shape repeatedly to make it flash again.
+                    HighlightSelection(selectedShape);
+                }
+            }
+            ImGui.EndChild();
+
+            // Column 3: Transfer Buttons between _diffShapes and _additionalShapes
+            // Transfer buttons become '>>' and '<<' to avoid problems with existing buttons called '>' and '<'
+            ImGui.TableSetColumnIndex(3);
+            ImGui.Dummy(new System.Numerics.Vector2(0, 40)); // spacing
+            if (ImGui.Button(" > ## column 4 move right") && _selectedDiffShapesIdx >= 0 &&
+                _selectedDiffShapesIdx < _diffShapes.Count)
+            {
+                _additionalShapes.Add(_diffShapes[_selectedDiffShapesIdx]);
+                _diffShapes.RemoveAt(_selectedDiffShapesIdx);
+                _selectedDiffShapesIdx = -1;
+            }
+
+            if (ImGui.Button(" < ## column 4 move left") && _selectedAdditionalShapesIdx >= 0 &&
+                _selectedAdditionalShapesIdx < _additionalShapes.Count)
+            {
+                _diffShapes.Add(_additionalShapes[_selectedAdditionalShapesIdx]);
+                _additionalShapes.RemoveAt(_selectedAdditionalShapesIdx);
+                _selectedAdditionalShapesIdx = -1;
+            }
+
+            // Column 5: _additionalShapes List
+            ImGui.TableSetColumnIndex(4);
+            ImGui.Text("AdditionalShapes");
+            ImGui.BeginChild("AdditionalRegion", new System.Numerics.Vector2(0, 100), true);
+            for (int i = 0; i < _additionalShapes.Count; i++)
+            {
+                bool isSelected = (_selectedAdditionalShapesIdx == i);
+                if (ImGui.Selectable(_additionalShapes[i].ToString(), isSelected))
+                {
+                    _selectedAdditionalShapesIdx = i;
+                    // Highlight a selected shape briefly so we can visually see which one we are focused on.
+                    var selectedShape = _additionalShapes[_selectedAdditionalShapesIdx];
+                    // Briefly highlight selected shape in list so we can visually tell where things are.
+                    HighlightSelection(selectedShape);
+                }
+            }
+
+            ImGui.EndChild();
+            ImGui.EndTable();
+
+            // Various item deletion options from Shapes lists
+            if (ImGui.Button(" Remove Single Shape") &&
+                ((_selectedDiffShapesIdx >= 0 && _selectedDiffShapesIdx < _diffShapes.Count) ||
+                 (_selectedUnionShapesIdx >= 0 && _selectedUnionShapesIdx < _unionShapes.Count) ||
+                 (_selectedAdditionalShapesIdx >= 0 && _selectedAdditionalShapesIdx < _additionalShapes.Count)))
+            {
+                if (_selectedDiffShapesIdx >= 0)
+                {
+                    _diffShapes.RemoveAt(_selectedDiffShapesIdx);
+                    _selectedDiffShapesIdx = -1;
+                }
+                else if (_selectedUnionShapesIdx >= 0)
+                {
+                    _unionShapes.RemoveAt(_selectedUnionShapesIdx);
+                    _selectedUnionShapesIdx = -1;
+                }
+                else if (_selectedAdditionalShapesIdx >= 0)
+                {
+                    _additionalShapes.RemoveAt(_selectedAdditionalShapesIdx);
+                    _selectedAdditionalShapesIdx = -1;
+                }
+            }
+
+            if (ImGui.Button("Clear Union List"))
+            {
+                _unionShapes.Clear();
+            }
+
+            ImGui.SameLine();
+            if (ImGui.Button("Clear Diff List"))
+            {
+                _diffShapes.Clear();
+            }
+
+            ImGui.SameLine();
+            if (ImGui.Button("Clear Additional List"))
+            {
+                _additionalShapes.Clear();
+            }
+
+            ImGui.SameLine();
+            if (ImGui.Button("Clear All Shapes"))
+            {
+                _unionShapes.Clear();
+                _selectedUnionShapesIdx = -1;
+                _diffShapes.Clear();
+                _selectedDiffShapesIdx = -1;
+                _additionalShapes.Clear();
+                _selectedAdditionalShapesIdx = -1;
+            }
+
+            if (ImGui.CollapsingHeader("Union Shapes List code snippet generation."))
+            {
+                ListCodeGenWidget(_unionShapes, "unionShapes");
+            }
+
+            if (ImGui.CollapsingHeader("Difference Shapes List code snippet generation."))
+            {
+                ListCodeGenWidget(_diffShapes, "diffShapes");
+            }
+
+            if (ImGui.CollapsingHeader("Additional Shapes List code snippet generation."))
+            {
+                ListCodeGenWidget(_additionalShapes, "additionalShapes");
+            }
+        }
+    }
+
+    // This is the code export button for a whole List<Shapes>
+    public void ListCodeGenWidget(List<Shape> shapes, string listName)
+    {
+        if (shapes.Count > 0)
+        {
+            // Show the preview of generated code. Then export button.
+            ImGui.TextWrapped(ListString(shapes, listName).ToString());
+            ListStringButton(shapes, listName);
+        }
+    }
+
+    // Pattern match the shapes so we can pull out the Center parameter. Then draw briefly for visual identification.
+    public void HighlightSelection(Shape shape)
+    {
+        switch (shape)
+        {
+            case Circle c:
+                // We use Camera.Instance.DrawWorldCircle because it looks better.
+                Camera.Instance!.DrawWorldCircle(
+                    new Vector3(c.Center.X, Service.ObjectTable.LocalPlayer!.Position.Y, c.Center.Z), c.Radius,
+                    Colors.Focus, 3f);
+                break;
+            case Rectangle r:
+                DrawCameraShape(r.Center, r, Colors.Focus, 3f);
+                break;
+            case Donut d:
+                DrawCameraShape(d.Center, d, Colors.Focus, 3f);
+                break;
+            case Cross cross:
+                DrawCameraShape(cross.Center, cross, Colors.Focus, 3f);
+                break;
+            case DonutSegmentHA donutSegmentHA:
+                DrawCameraShape(donutSegmentHA.Center, donutSegmentHA, Colors.Focus, 3f);
+                break;
+            case Ellipse ellipse:
+                DrawCameraShape(ellipse.Center, ellipse, Colors.Focus, 3f);
+                break;
+            case Capsule capsule:
+                DrawCameraShape(capsule.Center, capsule, Colors.Focus, 3f);
+                break;
+            default:
+                break;
+        }
+
+        ;
     }
 
     public static unsafe FFXIVClientStructs.FFXIV.Client.Graphics.Scene.Object* FindSceneRoot()
@@ -552,10 +1198,12 @@ sealed class DebugGraphics
         {
             DumpSceneNode(res, root, "");
         }
+
         Service.Log(res.ToString());
     }
 
-    private static unsafe void DumpSceneNode(StringBuilder res, FFXIVClientStructs.FFXIV.Client.Graphics.Scene.Object* o, string prefix)
+    private static unsafe void DumpSceneNode(StringBuilder res,
+        FFXIVClientStructs.FFXIV.Client.Graphics.Scene.Object* o, string prefix)
     {
         var start = o;
         do
@@ -567,14 +1215,14 @@ sealed class DebugGraphics
             }
 
             o = o->NextSiblingObject;
-        }
-        while (o != start);
+        } while (o != start);
     }
 
     private static unsafe string SceneNodeText(FFXIVClientStructs.FFXIV.Client.Graphics.Scene.Object* o)
     {
         var t = o->GetObjectType();
-        var s = $"0x{(IntPtr)o:X}: t={t}, flags={Utils.SceneObjectFlags(o):X}, pos={Utils.Vec3String(o->Position)}, rot={Utils.QuatString(o->Rotation)}, scale={Utils.Vec3String(o->Scale)}";
+        var s =
+            $"0x{(IntPtr)o:X}: t={t}, flags={Utils.SceneObjectFlags(o):X}, pos={Utils.Vec3String(o->Position)}, rot={Utils.QuatString(o->Rotation)}, scale={Utils.Vec3String(o->Scale)}";
         switch (t)
         {
             case ObjectType.VfxObject:

--- a/BossMod/Framework/Camera.cs
+++ b/BossMod/Framework/Camera.cs
@@ -79,12 +79,15 @@ sealed class Camera
         var p2p = Vector4.Transform(p2w, ViewProj);
         var p1c = p1p.XY() * (1 / p1p.W);
         var p2c = p2p.XY() * (1 / p2p.W);
-        var p1screen = new Vector2(0.5f * ViewportSize.X * (1 + p1c.X), 0.5f * ViewportSize.Y * (1 - p1c.Y)) + ImGuiHelpers.MainViewport.Pos;
-        var p2screen = new Vector2(0.5f * ViewportSize.X * (1 + p2c.X), 0.5f * ViewportSize.Y * (1 - p2c.Y)) + ImGuiHelpers.MainViewport.Pos;
+        var p1screen = new Vector2(0.5f * ViewportSize.X * (1 + p1c.X), 0.5f * ViewportSize.Y * (1 - p1c.Y)) +
+                       ImGuiHelpers.MainViewport.Pos;
+        var p2screen = new Vector2(0.5f * ViewportSize.X * (1 + p2c.X), 0.5f * ViewportSize.Y * (1 - p2c.Y)) +
+                       ImGuiHelpers.MainViewport.Pos;
         _worldDrawLines.Add(new(p1screen, p2screen, color, thickness));
     }
 
-    public void DrawWorldCone(Vector3 center, float radius, Angle direction, Angle halfWidth, uint color, float thickness = 1)
+    public void DrawWorldCone(Vector3 center, float radius, Angle direction, Angle halfWidth, uint color,
+        float thickness = 1)
     {
         var numSegments = CurveApprox.CalculateCircleSegments(radius, halfWidth, maxerror);
         var delta = halfWidth / numSegments;
@@ -97,6 +100,7 @@ sealed class Camera
             DrawWorldLine(prev, curr, color, thickness);
             prev = curr;
         }
+
         DrawWorldLine(prev, center, color, thickness);
     }
 
@@ -109,6 +113,113 @@ sealed class Camera
             var curr = center + radius * (i * 360.0f / numSegments).Degrees().ToDirection().ToVec3();
             DrawWorldLine(curr, prev, color, thickness);
             prev = curr;
+        }
+    }
+
+    // Pass in both Vec 3 center and Shape rectangle so we have the Y coordinate as well.
+    public void DrawWorldRectangle(Vector3 center, Rectangle rectangle, uint color, float thickness = 1)
+    {
+        var pos = rectangle.Center;
+        // pull out the 4 vertices directly from Shape Rectangle.
+        var dirs = rectangle.Contour(pos);
+        var numSides = 4; //rectangles have 4 sides
+
+
+        if (dirs.Count == 0)
+            return;
+        // align each line with vec3 center so that it is drawn at the correct Y value.
+        var prev = center + dirs[3].ToVec3();
+        // If the list of dirs has values we start at dirs[0] for first line and loop through the
+        // array until we end up back at dirs[0]
+        for (var i = 0; i < numSides; ++i)
+        {
+            var curr = center + dirs[i].ToVec3();
+            DrawWorldLine(curr, prev, color, thickness);
+            prev = curr;
+        }
+    }
+
+    // Shape agnostic drawing logic. Every Shape in Shapes.cs has a contour that is a list of WDir. Just pull that information
+    // and peg it to the vec3 center for arena height. Camera doesn't need to redo the logic, just use what Shapes delivers.
+    public void DrawWorldShape(Vector3 center, Shape shape, uint color, float thickness = 1)
+    {
+        WPos pos = new WPos(center.X, center.Z);
+        var dirs = shape.Contour(pos);
+        var dirsCount = dirs.Count;
+
+        if (dirs.Count == 0)
+            return;
+        // align each line with vec3 center so that it is drawn at the correct Y value.
+        var prev = center +
+                   dirs[dirsCount - 1]
+                       .ToVec3(); // Start from the last point so we can complete the outline of the shape
+        // If the list of dirs has values we start at dirs[0] for first line and loop through the
+        // array until we end up back at dirs[0]
+        for (var i = 0; i < dirsCount; ++i)
+        {
+            var curr = center + dirs[i].ToVec3();
+            DrawWorldLine(curr, prev, color, thickness);
+            prev = curr;
+        }
+    }
+
+    // Draw a shape from a polygon such as customArenaBounds : adapted from MiniArena.cs
+    // Curves and circles will not look clean because these guts were designed for tiny radar shapes in mind.
+    // Import to radar and then determine if it looks right instead of being bothered by jaggy curves for now.
+    public void DrawWorldPoly(Vector3 center, RelSimplifiedComplexPolygon poly, uint color, float thickness = 1)
+    {
+        var parts = CollectionsMarshal.AsSpan(poly.Parts);
+        var len = parts.Length;
+
+        for (var i = 0; i < len; ++i)
+        {
+            var part = parts[i];
+
+            DrawContour(part.Exterior);
+            var countH = part.HoleStarts.Count;
+            for (var h = 0; h < countH; ++h)
+            {
+                DrawContour(part.Interior(h));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void DrawContour(ReadOnlySpan<WDir> contour)
+        {
+            var len = contour.Length;
+            Span<Vector3> points = stackalloc Vector3[len];
+
+            for (var i = 0; i < len; ++i)
+            {
+                points[i] = center + contour[i].ToVec3();
+            }
+            DrawPolygon(points);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        unsafe void DrawPolygon(Span<Vector3> points)
+        {
+            // fixed keyword to pin points in memory so GC doesn't relocate or dispose of any of them.
+            fixed (Vector3* p = points)
+            {
+                var len = points.Length;
+                Vector3* prevPtr = p + (len - 1);
+                Vector3 prev = *prevPtr;
+
+                for (var i = 0; i < len; ++i)
+                {
+                    Vector3* currentPtr = p;
+                    // moves the pointer to the i'th address
+                    if (i != 0)
+                        currentPtr = p + i;
+                    // Grabs the value of the pointer
+                    Vector3 currPtrValue = *currentPtr;
+                    var curr = currPtrValue;
+
+                    DrawWorldLine(curr, prev, color, thickness);
+                    prev = curr;
+                }
+            }
         }
     }
 
@@ -157,6 +268,7 @@ sealed class Camera
                 b = p;
             }
         }
+
         return true;
     }
 }


### PR DESCRIPTION
A bunch of ui additions in order to support shape templates moving around in overlay and being saved and drawn. It will also make an arenaBoundsCustom shape and draw that in the overlay based off of saved shapes.

I did an auto format using the ide shortcut. In theory it follows the format guidelines from the repo. Some of the results feel odd to me but I left them in for now. I don't mind changing them in the next pass if it bugs anybody. 

Currently supports a limited selection of Shapes from Shapes.cs. The basic functionality uses the Contour(pos) that is built into Shapes.cs to draw the points over the area where the character is standing. 

Once a shape template is chosen from the drop down new buttons will appear based on the shape parameters. If a shape is then added to one of Union, Difference, or Additional Lists then some new UI widgets appear to show their contents and offer various List management options. There is protection to prevent multiple copies of a shape from being added to any of the Lists.



###########################################
Following is some instructions on how to add in new shapes from Shapes.cs ~ I am brain dumping here for a future wiki page or some record so that when future me forgets or somebody else wants a shape that is currently unsupported they know where to look.

Support can be added for more shapes but it isn't super clean just now.  There are 4 places to add to : a list of shape template names, and three switches in various parts of the code. The names for each in order to use a find function to identify where it happens are below. It is possible (probable) that these can be combined in order to somewhat to reduce repetitive pattern matching. The first step is really just getting code merged in favor of incremental improvements rather than this feature growing into a monstrosity that is harder to track everything that is changed.

The shape name has to be added  case sensitive to :
`private readonly string[] _shapeTemplates =`

Then there are three switches that need entries for each Shape

In `public void InsertShapesIntoOverlay(string shape)` we add a switch branch for Shape name case sensitive and then call the UI widgets to populate what buttons and sliders will appear to set the params as defined in the constructor from Shapes.cs. Then create the shape and pass that shape to the Camera to draw the template on screen. 

To start with the shape overlay drawing select a Shape from the drop down in debug graphics overlay.

Shape parameter buttons and sliders adjust per shape. When a shape is saved to one of the Union, Difference, or Additional Lists then a list box widget will appear to show contents.

There is code generation buttons for the various drawn shapes and lists. Then add the buttons for showing code snippets and exporting code or adding shapes to Lists, etc. Look at other switch branches in the method for examples. 

The second switch is in `public StringBuilder ShapeString(Shape shape)`. This is the code generation method. Construct the StringBuilder so that it outputs a new() shape for the shape. Do not add a semicolon or comma at the end of the string as that will break the List code generation. For example pushing the 'Copy Circle To Clipboard' button generates something like : `new Circle(new WPos(0.19f, 3.02f), 0.50f)`
Use the same format in existing branches of this method that interpolate fields directly from the shape object.

The third switch is in `public void HighlightSelection(Shape shape)` this is a quick camera draw that happens if the List Box widgets are up because a shape has been added to one of the Union, Difference, or Additional Lists. When you highlight a shape listed in one of the list box the shape will flash for a frame  so you can tell which shape it is on the overlay. Click multiple times to make it flash.

