### PR TITLE
ClyteumB1: Clear PlayerState when TrackingBeam stops rendering

### DIFF
--- a/BossMod/Modules/Dawntrail/Dungeon/D13TheClyteum/D131EyeoftheScorpion.cs
+++ b/BossMod/Modules/Dawntrail/Dungeon/D13TheClyteum/D131EyeoftheScorpion.cs
@@ -71,6 +71,12 @@ sealed class MotionTracker(BossModule module) : Components.StayMove(module)
             else if (renderflags == 16384)
             {
                 TrackingBeam = null;
+                // clear the special state when the thing despawns, just in case you're hanging out right at the edge.
+                var group = Raid.WithSlot(true);
+                foreach (var p in group)
+                {
+                    PlayerStates[p.Item1] = default;
+                }
             }
         }
     }


### PR DESCRIPTION
Should fix players getting 'stuck' in certain cases where they're at the edge.