### PR TITLE
Fixed radar window not sizing down on radar recenter. 

### DIFF
--- a/BossMod/BossModule/BossModuleConfig.cs
+++ b/BossMod/BossModule/BossModuleConfig.cs
@@ -5,6 +5,8 @@ namespace BossMod;
 [ConfigDisplay(Name = "Boss modules and radar", Order = 1)]
 public sealed class BossModuleConfig : ConfigNode
 {
+    public bool RadarResize;
+
     public override void DrawCustom(UITree tree, WorldState ws)
     {
         if (ImGui.Button("Recenter Window"))
@@ -25,7 +27,7 @@ public sealed class BossModuleConfig : ConfigNode
 
     // radar window settings
     [PropertyDisplay("Enable radar", separator: true)]
-    public bool Enable = true;
+    public bool EnableRadar = true;
 
     [PropertyDisplay("Enable projecting radar into the 3D world")]
     public bool ProjectRadarInto3DWorld = false;

--- a/BossMod/BossModule/BossModuleMainWindow.cs
+++ b/BossMod/BossModule/BossModuleMainWindow.cs
@@ -23,7 +23,7 @@ public sealed class BossModuleMainWindow : UIWindow
     public override void PreOpenCheck()
     {
         var showZoneModule = ShowZoneModule();
-        IsOpen = BossModuleManager.Config.Enable && (_mgr.LoadedModules.Count > 0 || showZoneModule);
+        IsOpen = BossModuleManager.Config.EnableRadar && (_mgr.LoadedModules.Count > 0 || showZoneModule);
         ShowCloseButton = _mgr.ActiveModule != null && !showZoneModule;
         WindowName = (showZoneModule ? $"Zone module ({_zmm.ActiveModule?.GetType().Name})" : _mgr.ActiveModule != null ? $"Boss module ({_mgr.ActiveModule.GetType().Name})" : "Loaded boss modules") + _windowID;
         Flags = ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse;
@@ -44,7 +44,7 @@ public sealed class BossModuleMainWindow : UIWindow
             DrawMovementHints(_mgr.ActiveModule.CalculateMovementHintsForRaidMember(PartyState.PlayerSlot, pc), pc.PosRot.Y);
         }
 
-        if (!BossModuleManager.Config.Enable && BossModuleManager.Config.ProjectRadarInto3DWorld)
+        if (!BossModuleManager.Config.EnableRadar && BossModuleManager.Config.ProjectRadarInto3DWorld)
         {
             var module = _mgr.ActiveModule;
             if (module == null)
@@ -144,6 +144,7 @@ public sealed class BossModuleMainWindow : UIWindow
     public void RecenterWindow()
     {
         _shouldRecenter = true;
+        MiniArena.Config.RadarResize = true;
     }
 
     private bool ShowZoneModule() => BossModuleManager.Config.ShowGlobalHints && !BossModuleManager.Config.HintsInSeparateWindow && _mgr.ActiveModule?.StateMachine.ActivePhase == null && (_zmm.ActiveModule?.WantDrawHints() ?? false);

--- a/BossMod/BossModule/MiniArena.cs
+++ b/BossMod/BossModule/MiniArena.cs
@@ -14,6 +14,7 @@ public sealed class MiniArena(WPos center, ArenaBounds bounds)
 {
     public static readonly BossModuleConfig Config = Service.Config.Get<BossModuleConfig>();
     private WPos _center = center;
+    private Vector2 _currentWindowSize = new (400, 900);
 
     public WPos Center
     {
@@ -117,7 +118,7 @@ public sealed class MiniArena(WPos center, ArenaBounds bounds)
     private readonly List<WorldPathCommand> _worldPathCommands = [with(32)];
     private static MiniArena? _worldPathOwner;
 
-    // Actor markers normally sit directly under a known actor. 
+    // Actor markers normally sit directly under a known actor.
     // ActorProjected deliberately opts back into the bounds' WorldProjectionHeight because its
     // destination marker is usually not underneath an actor. A zero bounds/layer height overrides
     // the shallow marker band as well so reference-plane projection remains arena-wide.
@@ -126,7 +127,7 @@ public sealed class MiniArena(WPos center, ArenaBounds bounds)
     private const float WorldOutlineUnit = 0.08f;
     // 3D arena-rim Dimensions
     private const float WorldArenaRimHeight = 0.35f;
-    // Keep the lower rail slightly above the provisional reference plane. This avoids fighting the scene depth of a coplanar floor while 
+    // Keep the lower rail slightly above the provisional reference plane. This avoids fighting the scene depth of a coplanar floor while
     // still reading visually as the arena's ground contact edge
     private const float WorldArenaRimBaseLift = 0.075f;
     private const float WorldArenaRimSupportSpacing = 2.0f;
@@ -137,6 +138,41 @@ public sealed class MiniArena(WPos center, ArenaBounds bounds)
     public WPos ClampToBounds(WPos position) => _center + _bounds.ClampToBounds(position - _center);
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public float IntersectRayBounds(WPos rayOrigin, in WDir rayDir) => _bounds.IntersectRay(rayOrigin - _center, rayDir);
+
+    public void SetWindowSize(Vector2 fullSize)
+    {
+        var resize = new Vector2(400, 900);
+
+        if (Config.RadarResize)
+        {
+            // Resize the radar arena back to original value also.
+            Config.ArenaScale = 1.0f;
+
+            _currentWindowSize = resize;
+            Config.RadarResize = false;
+        }
+        else
+        {
+            _currentWindowSize = ImGui.GetWindowSize();
+        }
+        var requiredWindowSize = Vector2.Max(fullSize, _currentWindowSize);
+        ImGui.SetWindowSize(requiredWindowSize, ImGuiCond.Always);
+    }
+
+    // Right click anywhere on mini radar window to recenter and resize.
+    public void DrawContextMenu()
+    {
+        // Opens context menu on right mouse click of the mini radar
+        if (ImGui.BeginPopupContextWindow("MyWindowContext", ImGuiPopupFlags.MouseButtonRight))
+        {
+            if (ImGui.MenuItem("Recenter and Resize Radar"))
+            {
+                Service.BossModWindow?.RecenterWindow();
+            }
+            ImGui.EndPopup();
+        }
+    }
+
 
     // prepare for drawing - set up internal state, clip rect etc.
     public void Begin(Angle cameraAzimuth, Actor primaryActor, Actor player, bool draw2D = true)
@@ -239,9 +275,10 @@ public sealed class MiniArena(WPos center, ArenaBounds bounds)
 
             var centerOffset = new Vector2(screenMarginSize + Config.SlackForRotations * screenHalfSize);
             var fullSize = 2f * centerOffset;
-            var currentWindowSize = ImGui.GetWindowSize();
-            var requiredWindowSize = Vector2.Max(fullSize, currentWindowSize);
-            ImGui.SetWindowSize(requiredWindowSize);
+
+            SetWindowSize(fullSize);
+            DrawContextMenu();
+
             var cursor = ImGui.GetCursorScreenPos();
             ImGui.Dummy(fullSize);
 
@@ -279,7 +316,7 @@ public sealed class MiniArena(WPos center, ArenaBounds bounds)
                 Dx11ArenaRenderer.AppendArenaBackground(Colors.Background);
             }
         }
-        // Make the current player's authored floor (or its shared disjoint-island group) the 2D stencil. 
+        // Make the current player's authored floor (or its shared disjoint-island group) the 2D stencil.
         // Explicit mechanic scopes may switch to one physical floor without changing the transform.
         if (layeredBounds != null && _frameArenaProjectionLayer is int currentLayer)
         {

--- a/BossMod/Framework/Plugin.cs
+++ b/BossMod/Framework/Plugin.cs
@@ -564,19 +564,23 @@ public sealed class Plugin : IAsyncDalamudPlugin
 
     private static bool ToggleRadar(string[] messageData)
     {
-        var config = Service.Config.Get<BossModuleConfig>();
+        // Use existing config. Having two streams open to one config causes problems.
+        var config = MiniArena.Config;
 
         if (messageData.Length == 1)
-            config.Enable = !config.Enable;
+            config.EnableRadar = !config.EnableRadar;
         else
         {
             switch (messageData[1].ToUpperInvariant())
             {
                 case "ON":
-                    config.Enable = true;
+                    config.EnableRadar = true;
                     break;
                 case "OFF":
-                    config.Enable = false;
+                    config.EnableRadar = false;
+                    break;
+                case "RESET":
+                    Service.BossModWindow?.RecenterWindow();
                     break;
                 default:
                     Service.ChatGui.Print($"[BMR] Unknown radar command: {messageData[1]}");
@@ -585,7 +589,7 @@ public sealed class Plugin : IAsyncDalamudPlugin
         }
 
         config.Modified.Fire();
-        Service.Log($"Radar is now {(config.Enable ? "enabled" : "disabled")}");
+        Service.Log($"Radar is now {(config.EnableRadar ? "enabled" : "disabled")}");
         return true;
     }
 }


### PR DESCRIPTION
Added command `/bmr radar reset` and right click on window for reset context menu. 

The window will still stay big if you scale the radar scaling down after scaling it large. Just right click the radar window to make it smaller if you want instead of dragging the window forever in hopes of finding a grip resize field.

Updated the radar enable boolean name from 'Enable' to 'EnableRadar' so that it is more clear what is being enabled.
Set Plugin.cs to use the existing MiniArena.Config instead of opening a second stream. As a byproduct it fixed a minor bug about the file already being open elsewhere and not being able to i/o.

Fix is for this ticket:
https://github.com/FFXIV-CombatReborn/BossmodReborn/issues/1112