### PR TITLE
Fix/tactical trial2 wierdness

### DIFF
--- a/BossMod/Modules/Global/HallOfTheNovice/NoviceTactical.cs
+++ b/BossMod/Modules/Global/HallOfTheNovice/NoviceTactical.cs
@@ -141,7 +141,6 @@ class StartingPositions(BossModule module) : BossComponent(module)
                         5 => new WPos(-2.815f, 2.137f),
                         0x10 => new WPos(-1.511f, 4.501f),
                         0x18 => new WPos(0f, 5.020f),
-
                         _ => null
                     },
                 1014 => // NA03 React to Advanced Visual Indicators

--- a/BossMod/Modules/Global/HallOfTheNovice/NoviceTactical.cs
+++ b/BossMod/Modules/Global/HallOfTheNovice/NoviceTactical.cs
@@ -140,7 +140,8 @@ class StartingPositions(BossModule module) : BossComponent(module)
                         4 => new WPos(-11.719f, 2.587f),
                         5 => new WPos(-2.815f, 2.137f),
                         0x10 => new WPos(-1.511f, 4.501f),
-                        0x18 => new WPos(1.999f, 5.020f),
+                        0x18 => new WPos(0f, 5.020f),
+
                         _ => null
                     },
                 1014 => // NA03 React to Advanced Visual Indicators
@@ -443,7 +444,9 @@ class NA02UpwellKnockback(BossModule module) : Components.SimpleKnockbacks(modul
         }
     }
 }
-class NA02BlazingSurge(BossModule module) : Components.SimpleAOEGroups(module, [(uint)AID.NA02BlazingSurge1, (uint)AID.NA02BlazingSurge2], new AOEShapeCone(20f, 90.Degrees()), maxCasts: 1);
+
+class NA02BlazingSurge(BossModule module) : Components.SimpleAOEGroupsByTimewindow(module,
+    [(uint)AID.NA02BlazingSurge1, (uint)AID.NA02BlazingSurge2], new AOEShapeCone(20f, 90.Degrees()), expectedNumCasters: 1);
 #endregion
 
 #region NA03


### PR DESCRIPTION
Blazing surge updated to use SimpleAOEGroupsByTimewindow : when two AOE's casting times start at the same time they should be sorted by time window so the shorter cast time spell is visible first.

Minor adjustment to aihint circle that appears in the overlapping cast window.